### PR TITLE
Support search using regex

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 - New spout for searching Twitter (e.g. following hashtags) was added. ([#1213](https://github.com/fossar/selfoss/pull/1213))
 - Added option `reading_speed_wpm` for showing estimated reading time. ([#1232](https://github.com/fossar/selfoss/pull/1232))
 - Search query is now part of URL. ([#1216](https://github.com/fossar/selfoss/pull/1216))
+- Search will be carried out using regular expressions when the search query is wrapped in forward slashes, e.g. `/regex/`. The expression syntax is database specific. ([#1205](https://github.com/fossar/selfoss/pull/1205))
 
 ### Bug fixes
 - Reddit spout allows wider range of URLs, including absolute URLs and searches ([#1033](https://github.com/fossar/selfoss/pull/1033))

--- a/assets/js/helpers/uri.js
+++ b/assets/js/helpers/uri.js
@@ -62,5 +62,5 @@ export function makeEntriesLink(location, { filter, category, id, search }) {
 
     const searchParam = typeof search !== 'undefined' ? search : queryString?.get('search');
 
-    return path + (searchParam ? `?search=${searchParam}` : '');
+    return path + (searchParam ? `?search=${encodeURIComponent(searchParam)}` : '');
 }

--- a/assets/js/templates/SearchList.jsx
+++ b/assets/js/templates/SearchList.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import { useLocation, useHistory } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { makeEntriesLink } from '../helpers/uri';
@@ -7,7 +8,10 @@ import { makeEntriesLink } from '../helpers/uri';
 function splitTerm(term) {
     if (term == '') {
         return [];
+    } else if (term.match(/^\/.+\/$/)) {
+        return [term];
     }
+
     var words = term.match(/"[^"]+"|\S+/g);
     for (var i = 0; i < words.length; i++) {
         words[i] = words[i].replace(/"/g, '');
@@ -30,13 +34,18 @@ function joinTerm(words) {
 
 
 // remove search term
-function handleRemove({ index, location, history }) {
-    const queryString = new URLSearchParams(location.search);
-    const oldTerm = queryString.get('search');
+function handleRemove({ index, location, history, regexSearch }) {
+    let newterm;
+    if (regexSearch) {
+        newterm = '';
+    } else {
+        const queryString = new URLSearchParams(location.search);
+        const oldTerm = queryString.get('search');
 
-    const termArray = splitTerm(oldTerm);
-    termArray.splice(index, 1);
-    const newterm = joinTerm(termArray);
+        const termArray = splitTerm(oldTerm);
+        termArray.splice(index, 1);
+        newterm = joinTerm(termArray);
+    }
 
     history.push(makeEntriesLink(location, { search: newterm, id: null }));
 }
@@ -55,12 +64,13 @@ export default function SearchList() {
         return queryString.get('search') ?? '';
     }, [location.search]);
 
-    const terms = splitTerm(searchText);
+    const regexSearch = searchText.match(/^\/.+\/$/);
+    const terms = regexSearch ? [searchText] : splitTerm(searchText);
 
     return (
         terms.map((item, index) => {
             return (
-                <li key={index} onClick={() => handleRemove({ index, location, history })}>
+                <li key={index} onClick={() => handleRemove({ index, location, history, regexSearch })} className={classNames({ 'regex-search-term': regexSearch })}>
                     {item} <FontAwesomeIcon icon={['fas', 'times']} />
                 </li>
             );

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -382,6 +382,11 @@ span.offline-count.diff {
     cursor: pointer;
 }
 
+#search-list .regex-search-term {
+    background-color: #e3ad32;
+    border-right-color: #e3ad32;
+}
+
 /* content */
 
 #content {

--- a/src/daos/StatementsInterface.php
+++ b/src/daos/StatementsInterface.php
@@ -44,6 +44,15 @@ interface StatementsInterface {
     public static function isFalse($column);
 
     /**
+     * Combine expressions using OR operator.
+     *
+     * @param string ...$exprs expressions to combine
+     *
+     * @return string combined expression
+     */
+    public static function exprOr(...$exprs);
+
+    /**
      * check if CSV column matches a value.
      *
      * @param string $column CSV column to check
@@ -112,4 +121,14 @@ interface StatementsInterface {
      * @return string
      */
     public static function csvRow(array $a);
+
+    /**
+     * Match a value to a regular expression.
+     *
+     * @param string $value value to match
+     * @param string $regex regular expression
+     *
+     * @return string expression for matching
+     */
+    public static function matchesRegex($value, $regex);
 }

--- a/src/daos/mysql/Statements.php
+++ b/src/daos/mysql/Statements.php
@@ -56,6 +56,17 @@ class Statements implements \daos\StatementsInterface {
     }
 
     /**
+     * Combine expressions using OR operator.
+     *
+     * @param string ...$exprs expressions to combine
+     *
+     * @return string combined expression
+     */
+    public static function exprOr(...$exprs) {
+        return '(' . implode(' OR ', $exprs) . ')';
+    }
+
+    /**
      * check if CSV column matches a value.
      *
      * @param string $column CSV column to check
@@ -199,5 +210,18 @@ class Statements implements \daos\StatementsInterface {
         }
 
         return implode(',', $filtered);
+    }
+
+    /**
+     * Match a value to a regular expression.
+     *
+     * @param string $value value to match
+     * @param string $regex regular expression
+     *
+     * @return string expression for matching
+     */
+    public static function matchesRegex($value, $regex) {
+        // https://dev.mysql.com/doc/refman/5.7/en/regexp.html
+        return $value . ' REGEXP ' . $regex;
     }
 }

--- a/src/daos/pgsql/Statements.php
+++ b/src/daos/pgsql/Statements.php
@@ -108,4 +108,17 @@ class Statements extends \daos\mysql\Statements {
 
         return $rows;
     }
+
+    /**
+     * Match a value to a regular expression.
+     *
+     * @param string $value value to match
+     * @param string $regex regular expression
+     *
+     * @return string expression for matching
+     */
+    public static function matchesRegex($value, $regex) {
+        // https://www.postgresql.org/docs/12/functions-matching.html#FUNCTIONS-POSIX-REGEXP
+        return $value . ' ~ ' . $regex;
+    }
 }

--- a/src/daos/sqlite/Statements.php
+++ b/src/daos/sqlite/Statements.php
@@ -63,4 +63,17 @@ class Statements extends \daos\mysql\Statements {
 
         return $date->format('Y-m-d H:i:s');
     }
+
+    /**
+     * Match a value to a regular expression.
+     *
+     * @param string $value value to match
+     * @param string $regex regular expression
+     *
+     * @return string expression for matching
+     */
+    public static function matchesRegex($value, $regex) {
+        // https://www.sqlite.org/lang_expr.html#the_like_glob_regexp_and_match_operators
+        return $value . ' REGEXP ' . $regex;
+    }
 }

--- a/src/helpers/ViewHelper.php
+++ b/src/helpers/ViewHelper.php
@@ -24,12 +24,16 @@ class ViewHelper {
             return $content;
         }
 
-        if (!is_array($searchWords)) {
+        if (is_string($searchWords)) {
+            if (preg_match('#^/(?P<regex>.+)/$#', $searchWords, $matches)) {
+                return preg_replace('/(?!<[^<>])(' . $matches[1] . ')(?![^<>]*>)/', '<span class="found">$0</span>', $content);
+            }
+
             $searchWords = \helpers\Search::splitTerms($searchWords);
         }
 
         foreach ($searchWords as $word) {
-            $content = preg_replace('/(?!<[^<>])(' . $word . ')(?![^<>]*>)/i', '<span class="found">$0</span>', $content);
+            $content = preg_replace('/(?!<[^<>])(' . preg_quote($word, '/') . ')(?![^<>]*>)/i', '<span class="found">$0</span>', $content);
         }
 
         return $content;


### PR DESCRIPTION
When user searches a term starting and ending with a forward slash, the items will be matched against the regular expression between the slashes.

The syntax of the regular expressions is database-engine specific:

* MySQL uses POSIX extended https://dev.mysql.com/doc/refman/5.7/en/regexp.html
* PostgreSQL uses POSIX extended with some extensions https://www.sqlite.org/lang_expr.html#the_like_glob_regexp_and_match_operators
* SQLite uses PHP’s PCRE https://www.postgresql.org/docs/12/functions-matching.html#FUNCTIONS-POSIX-REGEXP, https://www.php.net/manual/en/book.pcre.php

------

~~The filtering works but the interface is still incomplete. In particular, the matches will not be highlighted in the articles, and the search regex will be shown split on spaces.~~ Fixed.