### PR TITLE
client: re-add styles to content

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
 - Significantly improved accessibility ([#1133](https://github.com/fossar/selfoss/pull/1133), [#1134](https://github.com/SSilence/selfoss/pull/1134) and [#1141](https://github.com/SSilence/selfoss/pull/1141))
 - Fixed marking more than 1000 items as read at the same time ([#1182](https://github.com/fossar/selfoss/issues/1182))
 - Fixed loading full text on pages containing ampersands in URLs ([#1188](https://github.com/fossar/selfoss/pull/1188))
+- Fixed missing styling in article contents ([#1221](https://github.com/fossar/selfoss/pull/1221))
 
 ### API changes
 - `tags` attribute is now consistently array of strings, numbers are numbers and booleans are booleans. **This might break third-party clients that have not updated yet.** ([#948](https://github.com/fossar/selfoss/pull/948))

--- a/assets/.sassrc
+++ b/assets/.sassrc
@@ -1,0 +1,3 @@
+{
+  "includePaths": ["node_modules"]
+}

--- a/assets/hashpassword.html
+++ b/assets/hashpassword.html
@@ -25,7 +25,7 @@
     <meta name="theme-color" content="#191718" />
 
     <!-- all css definitions -->
-    <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="styles/main.scss">
 
 </head>
 <body id="hashpasswordbody">

--- a/assets/index.html
+++ b/assets/index.html
@@ -27,7 +27,7 @@
     <meta name="theme-color" content="#191718" />
 
     <!-- all css definitions -->
-    <link rel="stylesheet" href="css/style.css" />
+    <link rel="stylesheet" href="styles/main.scss" />
 
     <!-- web application manifest -->
     <link rel="manifest" href="selfoss.webmanifest">

--- a/assets/opml.html
+++ b/assets/opml.html
@@ -25,7 +25,7 @@
         <meta name="theme-color" content="#191718" />
 
         <!-- all css definitions -->
-        <link rel="stylesheet" href="css/style.css" />
+        <link rel="stylesheet" href="styles/main.scss" />
     </head>
     <body id="opmlbody">
 

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -8592,6 +8592,15 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "sass": {
+      "version": "1.26.11",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.26.11.tgz",
+      "integrity": "sha512-W1l/+vjGjIamsJ6OnTe0K37U2DBO/dgsv2Z4c89XQ8ZOO6l/VwkqwLSqoYzJeJs6CLuGSTRWc91GbQFL3lvrvw==",
+      "dev": true,
+      "requires": {
+        "chokidar": ">=2.0.0 <4.0.0"
+      }
+    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -10159,6 +10168,11 @@
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
       "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
       "dev": true
+    },
+    "unreset-css": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unreset-css/-/unreset-css-1.0.1.tgz",
+      "integrity": "sha1-I2LB8QbqU73NWybDXCkIFya7sM4="
     },
     "unset-value": {
       "version": "1.0.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -16,7 +16,8 @@
     "jquery-hotkeys": "^0.2.2",
     "ramda": "^0.27.1",
     "reset-css": "^5.0.1",
-    "spectrum-colorpicker": "^1.8.1"
+    "spectrum-colorpicker": "^1.8.1",
+    "unreset-css": "^1.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.11.1",
@@ -28,6 +29,7 @@
     "parcel-bundler": "^1.12.3",
     "parcel-plugin-sw-cache": "^0.3.1",
     "prettier": "^2.0.0",
+    "sass": "^1.26.11",
     "stylelint": "^13.6.1",
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-config-standard": "^20.0.0",
@@ -39,7 +41,7 @@
     "fix:js": "npm run lint:js -- --fix",
     "lint": "npm run lint:js && npm run lint:styles",
     "lint:js": "eslint js/*.js",
-    "lint:styles": "stylelint css/*.css",
+    "lint:styles": "stylelint styles/*.scss",
     "dev": "parcel watch index.html opml.html hashpassword.html -d ../public/ --public-url ./",
     "build": "parcel build index.html opml.html hashpassword.html -d ../public/ --public-url ./"
   },

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -1,6 +1,6 @@
 @import '@fancyapps/fancybox/dist/jquery.fancybox.css';
 @import 'spectrum-colorpicker/spectrum.css';
-@import 'reset-css';
+@import 'reset-css/sass/reset';
 
 /* base */
 
@@ -519,6 +519,8 @@ span.offline-count.diff {
     overflow: hidden;
     padding: 0 1em;
     overflow-wrap: break-word;
+
+    @import 'unreset-css/unreset';
 }
 
 .entry-content a {
@@ -533,16 +535,9 @@ span.offline-count.diff {
 }
 
 .entry-content p {
+    // unreset uses 1em for bottom and top
+    margin-top: 0;
     margin-bottom: 0.6em;
-}
-
-.entry-content ol li {
-    list-style: decimal inside;
-}
-
-.entry-content li {
-    margin: 0.3em;
-    list-style: disc inside;
 }
 
 .entry-content blockquote {
@@ -579,15 +574,9 @@ span.offline-count.diff {
 }
 
 .entry-content dd {
+    // unreset adds margin
+    margin: 0;
     text-indent: 1.3em;
-}
-
-.entry-content sup {
-    vertical-align: super;
-}
-
-.entry-content sub {
-    vertical-align: sub;
 }
 
 .entry-icon {


### PR DESCRIPTION
Reset.css removes all styling including from elements like `<em>` or `<strong>`. Let’s reapply it in entry contents.

I had to switch to SASS to be able to use scoped @import.

The `unreset` library contains stuff we do not need (semantic layout elements) but it is still nicer than writing it from scratch.

Alternately, we could switch to something like normalize.css and remove stuff we do not want (e.g. list styling for `<ul>` in the sidebar) ourselves but that is more work and I am not sure how much sense it makes for us. https://css-tricks.com/reboot-resets-reasoning/

Fixes: #1220 