### PR TITLE
Article reading time

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 - [Native sharer](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share) is available in secure contexts in browsers that support it. You can enable it by adding `a` to `share` key in your config. ([#1035](https://github.com/fossar/selfoss/pull/1035))
 - Data directory can be configured ([#1043](https://github.com/fossar/selfoss/pull/1043))
 - New spout for searching Twitter (e.g. following hashtags) was added. ([#1213](https://github.com/fossar/selfoss/pull/1213))
+- Added option `reading_speed_wpm` for showing estimated reading time. ([#1232](https://github.com/fossar/selfoss/pull/1232))
 
 ### Bug fixes
 - Reddit spout allows wider range of URLs, including absolute URLs and searches ([#1033](https://github.com/fossar/selfoss/pull/1033))

--- a/assets/locale/en.json
+++ b/assets/locale/en.json
@@ -99,5 +99,6 @@
   "lang_error_share_native": "Unable to share item.",
   "lang_info_url_copied": "URL copied to clipboard.",
   "lang_close_entry": "Close",
-  "lang_article_actions": "Actions"
+  "lang_article_actions": "Actions",
+  "lang_article_reading_time": "{0} min read"
 }

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -593,6 +593,7 @@ span.offline-count.diff {
 }
 
 .entry-author,
+.entry-readtime,
 .entry-source,
 .entry-separator,
 .entry-datetime {

--- a/defaults.ini
+++ b/defaults.ini
@@ -40,3 +40,4 @@ camo_domain=
 camo_key=
 scroll_to_article_header=1
 show_thumbnails=1
+reading_speed_wpm=0

--- a/docs/content/docs/administration/options.md
+++ b/docs/content/docs/administration/options.md
@@ -284,3 +284,9 @@ If set to `0`, thumbnails are not shown in the collapsed view. Defaults to `1`.
 
 Location of the data directory; especially useful when selfoss is installed to write-protected file system. `.htaccess` file (or equivalent configuration file for non-Apache web servers) will need to be adjusted accordingly.
 </div>
+
+### `reading_speed_wpm`
+<div class="config-option">
+
+Reading speed in words per minute used to calculate the estimated reading time of each article. On average, adults can read between 200 and 300 wpm and you can find many tools that can help you determine your reading speed on-line. If set to `0` (the default value), the estimated reading time is not shown.
+</div>

--- a/src/controllers/About.php
+++ b/src/controllers/About.php
@@ -55,6 +55,7 @@ class About {
                 'allowPublicUpdate' => $f3->get('allow_public_update_access') == 1, // bool
                 'publicMode' => $f3->get('public') == 1, // bool
                 'authEnabled' => $this->authentication->enabled() === true, // bool
+                'readingSpeed' => $f3->get('reading_speed_wpm') > 0 ? (int) $f3->get('reading_speed_wpm') : null, // ?int
                 'language' => $f3->get('language') === 0 ? null : $f3->get('language'), // ?string
                 'userCss' => file_exists(BASEDIR . '/user.css') ? filemtime(BASEDIR . '/user.css') : null, // ?int
                 'userJs' => file_exists(BASEDIR . '/user.js') ? filemtime(BASEDIR . '/user.js') : null, // ?int

--- a/src/templates/item.phtml
+++ b/src/templates/item.phtml
@@ -57,6 +57,12 @@
     <!-- datetime -->
     <a href="<?= \helpers\Anonymizer::anonymize($this->item['link']); ?>" class="entry-datetime" target="_blank" rel="noopener noreferrer"></a>
 
+    <!-- read time -->
+    <?php if (\F3::get('reading_speed_wpm') > 0) : ?>
+    <span class="entry-separator">&bull;</span>
+    <span class="entry-readtime"><?= \F3::get('lang_article_reading_time', round((str_word_count(strip_tags($content)) / \F3::get('reading_speed_wpm'))))?></span>
+    <?php endif; ?>
+
     <!-- thumbnail -->
     <?php if (\F3::get('show_thumbnails') && isset($this->item['thumbnail']) && strlen(trim($this->item['thumbnail'])) > 0) : ?>
     <div class="entry-thumbnail">


### PR DESCRIPTION
This addition displays an estimated reading time near the title of each article.
It allows me to estimate how long an article is before opening it.
It is just a small hack I made for my own use and I do not know if it actually is an useful feature for others... if it's not feel free to delete this PR.