### PR TITLE
client: Cancel previous requests more reliably

### DIFF
--- a/assets/.eslintrc.json
+++ b/assets/.eslintrc.json
@@ -38,6 +38,9 @@
         "object-curly-newline": ["error", {"multiline": true, "consistent": true}],
         "one-var-declaration-per-line": "error",
         "quotes": ["error", "single", {"avoidEscape": true}],
+        "react-hooks/exhaustive-deps": ["warn", {
+          "additionalHooks": "(useStateWithDeps)"
+        }],
         "semi": "error",
         "semi-spacing": "error",
         "space-before-blocks": "error",

--- a/assets/js/helpers/ajax.js
+++ b/assets/js/helpers/ajax.js
@@ -73,7 +73,7 @@ export const liftToPromiseField = (wrapper) => (f) => (...params) => {
  * @return {controller: AbortController, promise: Promise}
  */
 export const makeAbortableFetch = (fetch) => (url, opts = {}) => {
-    let controller = new AbortController();
+    let controller = opts.abortController || new AbortController();
     let promise = fetch(url, {
         signal: controller.signal,
         ...opts

--- a/assets/js/requests/items.js
+++ b/assets/js/requests/items.js
@@ -78,18 +78,14 @@ function enrichItemsResponse(data) {
 /**
  * Get all items matching given filter.
  */
-export function getItems(filter) {
-    const { controller, promise } = ajax.get('', {
+export function getItems(filter, abortController) {
+    return ajax.get('', {
         body: ajax.makeSearchParams({
             ...filter,
             fromDatetime: filter.fromDatetime ? filter.fromDatetime.toISOString() : filter.fromDatetime
-        })
-    });
-
-    return {
-        controller,
-        promise: promise.then(response => response.json()).then(enrichItemsResponse)
-    };
+        }),
+        abortController,
+    }).promise.then(response => response.json()).then(enrichItemsResponse);
 }
 
 /**

--- a/assets/js/requests/sources.js
+++ b/assets/js/requests/sources.js
@@ -40,13 +40,10 @@ export function remove(id) {
 /**
  * Gets all sources.
  */
-export function getAllSources() {
-    const { controller, promise } = ajax.get('sources');
-
-    return {
-        controller,
-        promise: promise.then(response => response.json())
-    };
+export function getAllSources(abortController) {
+    return ajax.get('sources', {
+        abortController,
+    }).promise.then(response => response.json());
 }
 
 /**

--- a/assets/js/selfoss-base.js
+++ b/assets/js/selfoss-base.js
@@ -23,11 +23,6 @@ var selfoss = {
     app: null,
 
     /**
-     * instance of the currently running XHR that is used to reload the items list
-     */
-    activeAjaxReq: null,
-
-    /**
      * the html title configured
      */
     htmlTitle: 'selfoss',

--- a/assets/js/selfoss-base.js
+++ b/assets/js/selfoss-base.js
@@ -424,7 +424,7 @@ var selfoss = {
 
     handleAjaxError: function(error, tryOffline = true) {
         if (!(error instanceof HttpError || error instanceof TimeoutError)) {
-            throw error;
+            return Promise.reject(error);
         }
 
         const httpCode = error?.response?.status || 0;
@@ -432,12 +432,7 @@ var selfoss = {
         if (tryOffline && httpCode != 403) {
             return selfoss.db.setOffline();
         } else {
-            if (httpCode == 403) {
-                selfoss.history.push('/login');
-                // TODO: Use location state once we switch to BrowserRouter
-                selfoss.app.setLoginFormError(selfoss.app._('error_session_expired'));
-            }
-            throw error;
+            return Promise.reject(error);
         }
     },
 

--- a/assets/js/selfoss-db-offline.js
+++ b/assets/js/selfoss-db-offline.js
@@ -234,7 +234,7 @@ selfoss.dbOffline = {
     },
 
 
-    reloadList: function(fetchParams) {
+    getEntries: function(fetchParams) {
         let hasMore = false;
         return selfoss.dbOffline._tr('r', selfoss.db.storage.entries,
             function() {

--- a/assets/js/selfoss-db-offline.js
+++ b/assets/js/selfoss-db-offline.js
@@ -25,7 +25,7 @@ selfoss.dbOffline = {
                 );
                 selfoss.db.broken = true;
                 selfoss.db.enableOffline.update(false);
-                selfoss.entries?.reloadList();
+                selfoss.entries?.reload();
 
                 // If this is a QuotaExceededError, garbage collect more
                 // entries and hope it helps.

--- a/assets/js/selfoss-db-online.js
+++ b/assets/js/selfoss-db-online.js
@@ -230,17 +230,11 @@ selfoss.dbOnline = {
      *
      * @return void
      */
-    reloadList: function(fetchParams) {
-        if (selfoss.activeAjaxReq !== null) {
-            selfoss.activeAjaxReq.controller.abort();
-        }
-
-        selfoss.activeAjaxReq = itemsRequests.getItems({
+    reloadList: function(fetchParams, abortController) {
+        return itemsRequests.getItems({
             ...fetchParams,
             itemsPerPage: selfoss.config.itemsPerPage
-        });
-
-        let promise = selfoss.activeAjaxReq.promise.then((data) => {
+        }, abortController).then((data) => {
             selfoss.db.setOnline();
 
             if (!selfoss.db.enableOffline.value) {
@@ -264,19 +258,14 @@ selfoss.dbOnline = {
                 hasMore: data.hasMore
             };
         }).catch((error) => {
-            if (error.name == 'AbortError') {
+            if (error.name === 'AbortError') {
                 return;
             }
 
             return selfoss.handleAjaxError(error).then(function() {
                 return selfoss.dbOffline.reloadList(fetchParams);
             });
-        }).finally(() => {
-            // clean up
-            selfoss.activeAjaxReq = null;
         });
-
-        return promise;
     }
 
 

--- a/assets/js/selfoss-db-online.js
+++ b/assets/js/selfoss-db-online.js
@@ -190,7 +190,7 @@ selfoss.dbOnline = {
             if ('stats' in data && data.stats.unread > 0 &&
                 selfoss.entriesPage && (selfoss.entriesPage.state.entries.length === 0 ||
                 selfoss.entriesPage.state.entries.loadingState === LoadingState.FAILURE)) {
-                selfoss.entriesPage?.reloadList();
+                selfoss.entriesPage?.reload();
             } else {
                 if ('itemUpdates' in data) {
                     selfoss.entriesPage.refreshEntryStatuses(data.itemUpdates);

--- a/assets/js/selfoss-db-online.js
+++ b/assets/js/selfoss-db-online.js
@@ -230,7 +230,7 @@ selfoss.dbOnline = {
      *
      * @return void
      */
-    reloadList: function(fetchParams, abortController) {
+    getEntries: function(fetchParams, abortController) {
         return itemsRequests.getItems({
             ...fetchParams,
             itemsPerPage: selfoss.config.itemsPerPage
@@ -263,7 +263,7 @@ selfoss.dbOnline = {
             }
 
             return selfoss.handleAjaxError(error).then(function() {
-                return selfoss.dbOffline.reloadList(fetchParams);
+                return selfoss.dbOffline.getEntries(fetchParams);
             });
         });
     }

--- a/assets/js/shortcuts.js
+++ b/assets/js/shortcuts.js
@@ -279,7 +279,7 @@ export default function makeShortcuts() {
 
         // 'r': Reload the current view
         'r': ignoreWhenInteracting(function() {
-            selfoss.entriesPage?.reloadList();
+            selfoss.entriesPage?.reload();
         }),
 
         // 'Shift + r': Refresh sources

--- a/assets/js/templates/EntriesPage.jsx
+++ b/assets/js/templates/EntriesPage.jsx
@@ -10,6 +10,7 @@ import { LoadingState } from '../requests/LoadingState';
 import { Spinner, SpinnerBig } from './Spinner';
 import classNames from 'classnames';
 import { LocalizationContext } from '../helpers/i18n';
+import { HttpError } from '../errors';
 
 function reloadList({ fetchParams, append = false, waitForSync = true, entryId = null, setLoadingState = selfoss.entriesPage.setLoadingState }) {
     if (entryId && fetchParams.fromId === undefined) {
@@ -81,6 +82,13 @@ function reloadList({ fetchParams, append = false, waitForSync = true, entryId =
             }
 
         }).catch((error) => {
+            if (error instanceof HttpError && error.response.status === 403) {
+                selfoss.history.push('/login');
+                // TODO: Use location state once we switch to BrowserRouter
+                selfoss.app.setLoginFormError(selfoss.app._('error_session_expired'));
+                return;
+            }
+
             setLoadingState(LoadingState.FAILURE);
             selfoss.app.showError(selfoss.app._('error_loading') + ' ' + error.message);
         });
@@ -629,6 +637,13 @@ export default class StateHolder extends React.Component {
                 }));
                 selfoss.dbOffline.enqueueStatuses(statuses);
             }).catch((error) => {
+                if (error instanceof HttpError && error.response.status === 403) {
+                    selfoss.history.push('/login');
+                    // TODO: Use location state once we switch to BrowserRouter
+                    selfoss.app.setLoginFormError(selfoss.app._('error_session_expired'));
+                    return;
+                }
+
                 this.setLoadingState(LoadingState.SUCCESS);
                 this.setEntries(oldEntries);
                 this.setHasMore(hadMore);

--- a/assets/js/templates/EntriesPage.jsx
+++ b/assets/js/templates/EntriesPage.jsx
@@ -254,9 +254,14 @@ export function EntriesPage({ entries, hasMore, loadingState, setLoadingState, s
 
     const _ = React.useContext(LocalizationContext);
 
+    if (loadingState === LoadingState.LOADING) {
+        return (
+            <SpinnerBig />
+        );
+    }
+
     return (
         <React.Fragment>
-            {loadingState === LoadingState.LOADING ? <SpinnerBig /> : null}
             {currentSource !== null && allowedToUpdate && isOnline ?
                 <button
                     type="button"

--- a/assets/js/templates/EntriesPage.jsx
+++ b/assets/js/templates/EntriesPage.jsx
@@ -36,16 +36,16 @@ function reloadList({ fetchParams, abortController, append = false, waitForSync 
             return Promise.resolve();
         }
 
-        let reloader = selfoss.dbOffline.reloadList;
+        let reloader = selfoss.dbOffline.getEntries;
 
         // tag, source and search filtering not supported offline (yet?)
         if (fetchParams.tag || fetchParams.source || fetchParams.search) {
-            reloader = selfoss.dbOnline.reloadList;
+            reloader = selfoss.dbOnline.getEntries;
         }
 
         var forceLoadOnline = selfoss.dbOffline.olderEntriesOnline || selfoss.dbOffline.shouldLoadEntriesOnline;
         if (!selfoss.db.enableOffline.value || (selfoss.db.online && forceLoadOnline)) {
-            reloader = selfoss.dbOnline.reloadList;
+            reloader = selfoss.dbOnline.getEntries;
         }
 
         // Clean state when not just adding items.

--- a/assets/js/templates/Item.jsx
+++ b/assets/js/templates/Item.jsx
@@ -9,6 +9,7 @@ import { makeEntriesLink } from '../helpers/uri';
 import * as itemsRequests from '../requests/items';
 import * as icons from '../icons';
 import { LocalizationContext } from '../helpers/i18n';
+import { HttpError } from '../errors';
 
 function anonymize(url) {
     return (selfoss.config.anonymizer ?? '') + url;
@@ -232,6 +233,13 @@ function handleStarredToggle({ event, entry }) {
         selfoss.handleAjaxError(error).then(function() {
             selfoss.dbOffline.enqueueStatus(id, 'starred', starr);
         }).catch(function(error) {
+            if (error instanceof HttpError && error.response.status === 403) {
+                selfoss.history.push('/login');
+                // TODO: Use location state once we switch to BrowserRouter
+                selfoss.app.setLoginFormError(selfoss.app._('error_session_expired'));
+                return;
+            }
+
             // rollback ui changes
             selfoss.entriesPage.starEntry(id, !starr);
             updateStats(!starr);
@@ -282,6 +290,13 @@ function handleReadToggle({ event, entry }) {
         selfoss.handleAjaxError(error).then(function() {
             selfoss.dbOffline.enqueueStatus(id, 'unread', !unread);
         }).catch(function(error) {
+            if (error instanceof HttpError && error.response.status === 403) {
+                selfoss.history.push('/login');
+                // TODO: Use location state once we switch to BrowserRouter
+                selfoss.app.setLoginFormError(selfoss.app._('error_session_expired'));
+                return;
+            }
+
             // rollback ui changes
             selfoss.entriesPage.markEntry(id, unread);
             updateStats(!unread);

--- a/assets/js/templates/NavTags.jsx
+++ b/assets/js/templates/NavTags.jsx
@@ -23,7 +23,7 @@ function Tag({ tag, active, collapseNav }) {
                 tagName,
                 color.toHexString()
             ).then(() => {
-                selfoss.entriesPage?.reloadList();
+                selfoss.entriesPage?.reload();
             }).catch((error) => {
                 selfoss.app.showError(selfoss.app._('error_saving_color') + ' ' + error.message);
             });

--- a/assets/js/templates/SourcesPage.jsx
+++ b/assets/js/templates/SourcesPage.jsx
@@ -4,6 +4,7 @@ import { SpinnerBig } from './Spinner';
 import * as sourceRequests from '../requests/sources';
 import { getAllSources } from '../requests/sources';
 import { LocalizationContext } from '../helpers/i18n';
+import { HttpError } from '../errors';
 
 function rand() {
     // https://www.php.net/manual/en/function.mt-getrandmax.php#117620
@@ -46,6 +47,13 @@ function loadSources({ setActiveAjaxReq, setSpouts, setSources }) {
             }
 
             selfoss.handleAjaxError(error, false).catch(function(error) {
+                if (error instanceof HttpError && error.response.status === 403) {
+                    selfoss.history.push('/login');
+                    // TODO: Use location state once we switch to BrowserRouter
+                    selfoss.app.setLoginFormError(selfoss.app._('error_session_expired'));
+                    return;
+                }
+
                 selfoss.app.showError(selfoss.app._('error_loading') + ' ' + error.message);
             });
         }).finally(() => {

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -31,7 +31,8 @@
         "rooks": "^5.0.2",
         "spectrum-colorpicker": "^1.8.1",
         "tinykeys": "^1.1.1",
-        "unreset-css": "^1.0.1"
+        "unreset-css": "^1.0.1",
+        "use-state-with-deps": "^1.1.1"
       },
       "devDependencies": {
         "@babel/core": "^7.12.10",
@@ -14312,6 +14313,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/use-state-with-deps": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/use-state-with-deps/-/use-state-with-deps-1.1.1.tgz",
+      "integrity": "sha512-eUy7deac8ncYiJM5GNjTVV1Bew1FXEXhYYUqJvdV8OakWRHovN5FSakDOgZulLTs0WiGGO92ariUc8+VQbZ5Dg==",
+      "peerDependencies": {
+        "react": "> 16.8.0"
+      }
+    },
     "node_modules/util": {
       "version": "0.12.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
@@ -25627,6 +25636,12 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "use-state-with-deps": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/use-state-with-deps/-/use-state-with-deps-1.1.1.tgz",
+      "integrity": "sha512-eUy7deac8ncYiJM5GNjTVV1Bew1FXEXhYYUqJvdV8OakWRHovN5FSakDOgZulLTs0WiGGO92ariUc8+VQbZ5Dg==",
+      "requires": {}
     },
     "util": {
       "version": "0.12.4",

--- a/assets/package.json
+++ b/assets/package.json
@@ -26,7 +26,8 @@
     "rooks": "^5.0.2",
     "spectrum-colorpicker": "^1.8.1",
     "tinykeys": "^1.1.1",
-    "unreset-css": "^1.0.1"
+    "unreset-css": "^1.0.1",
+    "use-state-with-deps": "^1.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",


### PR DESCRIPTION
This was always an issue but the React port made it extra obvious. Let’s have the components maintain their own `AbortController`s as suggested by <https://dev.to/viclafouch/cancel-properly-http-requests-in-react-hooks-and-avoid-memory-leaks-pd7>. It is cleaner too.
