### PR TITLE
common: Support MySQL through socket

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 - Data directory can be configured ([#1043](https://github.com/fossar/selfoss/pull/1043))
 - New spout for searching Twitter (e.g. following hashtags) was added. ([#1213](https://github.com/fossar/selfoss/pull/1213))
 - Added option `reading_speed_wpm` for showing estimated reading time. ([#1232](https://github.com/fossar/selfoss/pull/1232))
+- Added option `db_socket` for connecting to MySQL database through UNIX domain. ([#1284](https://github.com/fossar/selfoss/pull/1284))
 - Search query is now part of URL. ([#1216](https://github.com/fossar/selfoss/pull/1216))
 - Search will be carried out using regular expressions when the search query is wrapped in forward slashes, e.g. `/regex/`. The expression syntax is database specific. ([#1205](https://github.com/fossar/selfoss/pull/1205))
 - YouTube spout now supports following playlists. ([#1260](https://github.com/fossar/selfoss/pull/1260))

--- a/docs/content/docs/administration/options.md
+++ b/docs/content/docs/administration/options.md
@@ -53,6 +53,12 @@ Table prefix for MySQL/SQLite databases. This is useful to avoid conflicts when 
 Port for database connections. By default `3306` will be used for MySQL and `5432` for PostgreSQL.
 </div>
 
+### `db_socket`
+<div class="config-option">
+
+A UNIX domain socket used for connecting to the MySQL database server. Usually, you want to use `db_host=localhost`, which should use the default socket path (typically `/run/mysqld/mysqld.sock` for MySQL or `/run/postgresql` for PostgreSQL) but if you need to specify a different location, you can. This is orthogonal to `db_host` option.
+</div>
+
 ### `logger_destination`
 <div class="config-option">
 

--- a/src/helpers/Configuration.php
+++ b/src/helpers/Configuration.php
@@ -19,6 +19,9 @@ class Configuration {
         'ftrssCustomDataDir',
     ];
 
+    /** @var array<string, bool> Keeps track of options that have been changed. */
+    private $modifiedOptions = [];
+
     // Internal but overridable values.
 
     /** @var int debugging level @internal */
@@ -55,6 +58,9 @@ class Configuration {
 
     /** @var ?int */
     public $dbPort = null;
+
+    /** @var ?string */
+    public $dbSocket = null;
 
     /** @var string */
     public $dbPrefix = '';
@@ -217,6 +223,7 @@ class Configuration {
             }
 
             $this->{$propertyName} = $value;
+            $this->modifiedOptions[$propertyName] = true;
         }
 
         // Interpolate variables in the config values.
@@ -225,5 +232,16 @@ class Configuration {
             $value = $this->{$property};
             $this->{$property} = str_replace('%datadir%', $datadir, $value);
         }
+    }
+
+    /**
+     * Checks whether given configuration option has been changed.
+     *
+     * @param string $key
+     *
+     * @return bool
+     */
+    public function isChanged($key) {
+        return isset($this->modifiedOptions[$key]);
     }
 }


### PR DESCRIPTION
Unlike PostgreSQL, MySQL’s DSN needs a separate option for UNIX sockets. It also cannot handle ports with socket.

This will be useful for running tests with internal MySQL instance.
