### PR TITLE
Reduce fatfree usage some more

### DIFF
--- a/assets/js/templates/Item.jsx
+++ b/assets/js/templates/Item.jsx
@@ -339,7 +339,7 @@ export default function Item({ currentTime, item, selected, expanded, setNavExpa
     );
 
     const titleHtml = React.useMemo(
-        () => ({ __html: title }),
+        () => ({ __html: title ? title : selfoss.app._('no_title') }),
         [title]
     );
 

--- a/assets/js/templates/LoginForm.jsx
+++ b/assets/js/templates/LoginForm.jsx
@@ -20,8 +20,8 @@ function handleLogIn({
 
     selfoss.login({ username, password, offlineEnabled }).then(() => {
         history.push('/');
-    }).catch((error) => {
-        setError(error.message);
+    }).catch(() => {
+        setError(selfoss.app._('login_invalid_credentials'));
     }).finally(() => {
         setLoading(false);
     });

--- a/cliupdate.php
+++ b/cliupdate.php
@@ -3,5 +3,5 @@
 chdir(__DIR__);
 require __DIR__ . '/src/common.php';
 
-$loader = F3::get('CONTAINER')(\helpers\ContentLoader::class);
+$loader = $dice->create(helpers\ContentLoader::class);
 $loader->update();

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
         "php": ">= 5.6",
         "ext-gd": "*",
         "bcosca/fatfree-core": "^3.7.0",
+        "bramus/router": "^1.6",
         "danielstjules/stringy": "^3.1",
         "fossar/guzzle-transcoder": "^0.2.0",
         "fossar/htmlawed": "^1.2.4.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8b4e7b3be490c10b0bd0c4d63df28d61",
+    "content-hash": "c6028fdec0e065363013d1461e6009bd",
     "packages": [
         {
             "name": "bcosca/fatfree-core",
@@ -40,6 +40,57 @@
                 "source": "https://github.com/bcosca/fatfree-core/tree/3.7.3"
             },
             "time": "2020-12-13T12:49:39+00:00"
+        },
+        {
+            "name": "bramus/router",
+            "version": "1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bramus/router.git",
+                "reference": "55657b76da8a0a509250fb55b9dd24e1aa237eba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bramus/router/zipball/55657b76da8a0a509250fb55b9dd24e1aa237eba",
+                "reference": "55657b76da8a0a509250fb55b9dd24e1aa237eba",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.14",
+                "phpunit/php-code-coverage": "~2.0",
+                "phpunit/phpunit": "~4.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Bramus": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bram(us) Van Damme",
+                    "email": "bramus@bram.us",
+                    "homepage": "http://www.bram.us"
+                }
+            ],
+            "description": "A lightweight and simple object oriented PHP Router",
+            "homepage": "https://github.com/bramus/router",
+            "keywords": [
+                "router",
+                "routing"
+            ],
+            "support": {
+                "issues": "https://github.com/bramus/router/issues",
+                "source": "https://github.com/bramus/router/tree/1.6.1"
+            },
+            "time": "2021-11-18T19:24:07+00:00"
         },
         {
             "name": "clue/stream-filter",

--- a/index.php
+++ b/index.php
@@ -2,50 +2,159 @@
 
 require __DIR__ . '/src/common.php';
 
+$router = new Bramus\Router\Router();
+
 // define routes
 
 // all users
-$f3->route('GET /', controllers\Index::class . '->home'); // json
-$f3->route('GET /api/about', controllers\About::class . '->about'); // json
-$f3->route('GET /password', controllers\Authentication::class . '->password'); // html
-$f3->route('GET /login', controllers\Authentication::class . '->login'); // json
-$f3->route('POST /login', controllers\Authentication::class . '->login'); // json
-$f3->route('GET /logout', controllers\Authentication::class . '->logout'); // json
-$f3->route('GET /update', controllers\Sources\Update::class . '->updateAll'); // text
+$router->get('/', function() use ($dice) {
+    // json
+    $dice->create(controllers\Index::class)->home();
+});
+$router->get('/api/about', function() use ($dice) {
+    // json
+    $dice->create(controllers\About::class)->about();
+});
+$router->get('/password', function() use ($dice) {
+    // html
+    $dice->create(controllers\Authentication::class)->password();
+});
+$router->get('/login', function() use ($dice) {
+    // json
+    $dice->create(controllers\Authentication::class)->login();
+});
+$router->post('/login', function() use ($dice) {
+    // json
+    $dice->create(controllers\Authentication::class)->login();
+});
+$router->get('/logout', function() use ($dice) {
+    // json
+    $dice->create(controllers\Authentication::class)->logout();
+});
+$router->get('/update', function() use ($dice) {
+    // text
+    $dice->create(controllers\Sources\Update::class)->updateAll();
+});
 
 // only for loggedin users or on public mode
-$f3->route('GET /rss', controllers\Rss::class . '->rss'); // rss
-$f3->route('GET /feed', controllers\Rss::class . '->rss'); // rss
-$f3->route('GET /items', controllers\Items::class . '->listItems'); // json
-$f3->route('GET /tags', controllers\Tags::class . '->listTags'); // json
-$f3->route('GET /stats', controllers\Items\Stats::class . '->stats'); // json
-$f3->route('GET /items/sync', controllers\Items\Sync::class . '->sync'); // json
-$f3->route('GET /sources/stats', controllers\Sources::class . '->stats'); // json
+$router->get('/rss', function() use ($dice) {
+    // rss
+    $dice->create(controllers\Rss::class)->rss();
+});
+$router->get('/feed', function() use ($dice) {
+    // rss
+    $dice->create(controllers\Rss::class)->rss();
+});
+$router->get('/items', function() use ($dice) {
+    // json
+    $dice->create(controllers\Items::class)->listItems();
+});
+$router->get('/tags', function() use ($dice) {
+    // json
+    $dice->create(controllers\Tags::class)->listTags();
+});
+$router->get('/stats', function() use ($dice) {
+    // json
+    $dice->create(controllers\Items\Stats::class)->stats();
+});
+$router->get('/items/sync', function() use ($dice) {
+    // json
+    $dice->create(controllers\Items\Sync::class)->sync();
+});
+$router->get('/sources/stats', function() use ($dice) {
+    // json
+    $dice->create(controllers\Sources::class)->stats();
+});
 
 // only loggedin users
-$f3->route('POST /mark/@item', controllers\Items::class . '->mark'); // json
-$f3->route('POST /mark', controllers\Items::class . '->mark'); // json
-$f3->route('POST /unmark/@item', controllers\Items::class . '->unmark'); // json
-$f3->route('POST /starr/@item', controllers\Items::class . '->starr'); // json
-$f3->route('POST /unstarr/@item', controllers\Items::class . '->unstarr'); // json
-$f3->route('POST /items/sync', controllers\Items\Sync::class . '->updateStatuses'); // json
+$router->post('/mark/{itemId}', function($itemId) use ($dice) {
+    // json
+    $dice->create(controllers\Items::class)->mark($itemId);
+});
+$router->post('/mark', function() use ($dice) {
+    // json
+    $dice->create(controllers\Items::class)->mark();
+});
+$router->post('/unmark/{itemId}', function($itemId) use ($dice) {
+    // json
+    $dice->create(controllers\Items::class)->unmark($itemId);
+});
+$router->post('/starr/{itemId}', function($itemId) use ($dice) {
+    // json
+    $dice->create(controllers\Items::class)->starr($itemId);
+});
+$router->post('/unstarr/{itemId}', function($itemId) use ($dice) {
+    // json
+    $dice->create(controllers\Items::class)->unstarr($itemId);
+});
+$router->post('/items/sync', function() use ($dice) {
+    // json
+    $dice->create(controllers\Items\Sync::class)->updateStatuses();
+});
 
-$f3->route('GET /source/params', controllers\Sources::class . '->params'); // json
-$f3->route('GET /sources', controllers\Sources::class . '->show'); // json
-$f3->route('GET /source', controllers\Sources::class . '->add'); // json
-$f3->route('GET /sources/list', controllers\Sources::class . '->listSources'); // json
-$f3->route('POST /source/@id', controllers\Sources\Write::class . '->write'); // json
-$f3->route('POST /source', controllers\Sources\Write::class . '->write'); // json
-$f3->route('DELETE /source/@id', controllers\Sources::class . '->remove'); // json
-$f3->route('POST /source/delete/@id', controllers\Sources::class . '->remove'); // json
-$f3->route('POST /source/@id/update', controllers\Sources\Update::class . '->update'); // json
-$f3->route('GET /sources/spouts', controllers\Sources::class . '->spouts'); // json
+$router->get('/source/params', function() use ($dice) {
+    // json
+    $dice->create(controllers\Sources::class)->params();
+});
+$router->get('/sources', function() use ($dice) {
+    // json
+    $dice->create(controllers\Sources::class)->show();
+});
+$router->get('/source', function() use ($dice) {
+    // json
+    $dice->create(controllers\Sources::class)->add();
+});
+$router->get('/sources/list', function() use ($dice) {
+    // json
+    $dice->create(controllers\Sources::class)->listSources();
+});
+$router->post('/source/{id}', function($id) use ($dice) {
+    // json
+    $dice->create(controllers\Sources\Write::class)->write($id);
+});
+$router->post('/source', function() use ($dice) {
+    // json
+    $dice->create(controllers\Sources\Write::class)->write();
+});
+$router->delete('/source/{id}', function($id) use ($dice) {
+    // json
+    $dice->create(controllers\Sources::class)->remove($id);
+});
+$router->post('/source/delete/{id}', function($id) use ($dice) {
+    // json
+    $dice->create(controllers\Sources::class)->remove($id);
+});
+$router->post('/source/{id}/update', function($id) use ($dice) {
+    // json
+    $dice->create(controllers\Sources\Update::class)->update($id);
+});
+$router->get('/sources/spouts', function() use ($dice) {
+    // json
+    $dice->create(controllers\Sources::class)->spouts();
+});
 
-$f3->route('POST /tags/color', controllers\Tags::class . '->color'); // json
+$router->post('/tags/color', function() use ($dice) {
+    // json
+    $dice->create(controllers\Tags::class)->color();
+});
 
-$f3->route('GET /opml', controllers\Opml\ImportPage::class . '->show'); // html
-$f3->route('POST /opml', controllers\Opml\Import::class . '->add'); // json
-$f3->route('GET /opmlexport', controllers\Opml\Export::class . '->export'); // xml
+$router->get('/opml', function() use ($dice) {
+    // html
+    $dice->create(controllers\Opml\ImportPage::class)->show();
+});
+$router->post('/opml', function() use ($dice) {
+    // json
+    $dice->create(controllers\Opml\Import::class)->add();
+});
+$router->get('/opmlexport', function() use ($dice) {
+    // xml
+    $dice->create(controllers\Opml\Export::class)->export();
+});
+
+$router->set404(function() {
+    header('HTTP/1.1 404 Not Found');
+    echo 'Page not found.';
+});
 
 // dispatch
-$f3->run();
+$router->run();

--- a/index.php
+++ b/index.php
@@ -2,12 +2,6 @@
 
 require __DIR__ . '/src/common.php';
 
-// Load custom language
-$lang = $f3->get('language');
-if ($lang != '0' && $lang != '') {
-    $f3->set('LANGUAGE', $lang);
-}
-
 // define routes
 
 // all users

--- a/src/common.php
+++ b/src/common.php
@@ -33,13 +33,11 @@ error_reporting(E_ALL & ~E_DEPRECATED);
 
 $f3->set('AUTOLOAD', false);
 $f3->set('BASEDIR', BASEDIR);
-$f3->set('LOCALES', BASEDIR . '/assets/locale/');
 
 $configuration = new Configuration(__DIR__ . '/../config.ini', $_ENV);
 
 $f3->set('DEBUG', $configuration->debug);
 $f3->set('cache', $configuration->cache);
-$f3->set('language', $configuration->language);
 
 $dice = new Dice();
 
@@ -263,20 +261,20 @@ $f3->set('ONERROR',
             }
 
             if ($configuration->debug !== 0) {
-                echo $f3->get('lang_error') . ': ';
+                echo 'An error occurred' . ': ';
                 echo $f3->get('ERROR.text') . "\n";
                 echo $f3->get('ERROR.trace');
             } else {
                 if ($handler instanceof StreamHandler) {
-                    echo $f3->get('lang_error_check_log_file', $handler->getUrl()) . PHP_EOL;
+                    echo 'An error occured, please check the log file “' . $handler->getUrl() . '”.' . PHP_EOL;
                 } elseif ($handler instanceof ErrorLogHandler) {
-                    echo $f3->get('lang_error_check_system_logs') . PHP_EOL;
+                    echo 'An error occured, please check your system logs.' . PHP_EOL;
                 } else {
-                    echo $f3->get('lang_error') . PHP_EOL;
+                    echo 'An error occurred' . PHP_EOL;
                 }
             }
         } catch (Exception $e) {
-            echo $f3->get('lang_error_unwritable_logs') . PHP_EOL;
+            echo 'Unable to write logs.' . PHP_EOL;
             echo $e->getMessage() . PHP_EOL;
         }
     }

--- a/src/common.php
+++ b/src/common.php
@@ -206,10 +206,6 @@ $dice->addRule(helpers\ThumbnailStore::class, array_merge($shared, [
 // Fallback rule
 $dice->addRule('*', $substitutions);
 
-$f3->set('CONTAINER', function($class) use ($dice) {
-    return $dice->create($class);
-});
-
 $dice->addRule(Logger::class, [
     'shared' => true,
     'constructParams' => ['selfoss'],

--- a/src/controllers/Authentication.php
+++ b/src/controllers/Authentication.php
@@ -68,7 +68,7 @@ class Authentication {
 
         $this->view->jsonSuccess([
             'success' => false,
-            'error' => \F3::get('lang_login_invalid_credentials'),
+            'error' => 'Wrong username/password',
         ]);
     }
 

--- a/src/controllers/Index.php
+++ b/src/controllers/Index.php
@@ -2,6 +2,7 @@
 
 namespace controllers;
 
+use daos\ItemOptions;
 use helpers\Authentication;
 use helpers\View;
 use helpers\ViewHelper;
@@ -74,17 +75,11 @@ class Index {
 
         $this->authentication->needsLoggedInOrPublicMode();
 
-        // get search param
-        $search = null;
-        if (isset($options['search']) && strlen($options['search']) > 0) {
-            $search = $options['search'];
-        }
-
         // load tags
         $tags = $this->tagsDao->getWithUnread();
 
         // load items
-        $items = $this->loadItems($options, $tags, $search);
+        $items = $this->loadItems($options, $tags);
 
         // load stats
         $stats = $this->itemsDao->stats();
@@ -122,14 +117,14 @@ class Index {
      *
      * @param array $params request parameters
      * @param array $tags information about tags
-     * @param ?string $search optional search query
      *
      * @return array{entries: array, hasMore: bool} html with items
      */
-    private function loadItems(array $params, array $tags, $search = null) {
+    private function loadItems(array $params, array $tags) {
+        $options = ItemOptions::fromUser($params);
         $entries = [];
-        foreach ($this->itemsDao->get($params) as $item) {
-            $entries[] = $this->viewHelper->preprocessEntry($item, $this->tagsController, $tags, $search);
+        foreach ($this->itemsDao->get($options) as $item) {
+            $entries[] = $this->viewHelper->preprocessEntry($item, $this->tagsController, $tags, $options->search);
         }
 
         return [

--- a/src/controllers/Index.php
+++ b/src/controllers/Index.php
@@ -2,7 +2,6 @@
 
 namespace controllers;
 
-use Base;
 use helpers\Authentication;
 use helpers\View;
 use helpers\ViewHelper;
@@ -54,14 +53,12 @@ class Index {
      * home site
      * json
      *
-     * @param Base $f3 fatfree base instance
-     *
      * @return void
      */
-    public function home(Base $f3) {
+    public function home() {
         $options = $_GET;
 
-        if (!$f3->ajax()) {
+        if (!$this->view->isAjax()) {
             $home = BASEDIR . '/public/index.html';
             if (!file_exists($home)) {
                 http_response_code(500);

--- a/src/controllers/Items.php
+++ b/src/controllers/Items.php
@@ -33,20 +33,19 @@ class Items {
      * mark items as read. Allows one id or an array of ids
      * json
      *
-     * @param Base $f3 fatfree base instance
-     * @param array $params query string parameters
+     * @param ?int $itemId ID of item to mark as read
      *
      * @return void
      */
-    public function mark(Base $f3, array $params) {
+    public function mark($itemId = null) {
         $this->authentication->needsLoggedIn();
 
-        if (isset($params['item'])) {
-            $lastid = $params['item'];
+        if ($itemId !== null) {
+            $lastid = $itemId;
         } else {
-            $headers = \F3::get('HEADERS');
-            if (isset($headers['Content-Type']) && strpos($headers['Content-Type'], 'application/json') === 0) {
-                $body = \F3::get('BODY');
+            $contentType = $_SERVER['CONTENT_TYPE'] ?: '';
+            if (strpos($contentType, 'application/json') === 0) {
+                $body = file_get_contents('php://input');
                 $lastid = json_decode($body, true);
             } elseif (isset($_POST['ids'])) {
                 $lastid = $_POST['ids'];
@@ -71,21 +70,18 @@ class Items {
      * mark item as unread
      * json
      *
-     * @param Base $f3 fatfree base instance
-     * @param array $params query string parameters
+     * @param int $itemId id of an item to mark as unread
      *
      * @return void
      */
-    public function unmark(Base $f3, array $params) {
+    public function unmark($itemId) {
         $this->authentication->needsLoggedIn();
 
-        $lastid = $params['item'];
-
-        if (!$this->itemsDao->isValid('id', $lastid)) {
+        if (!$this->itemsDao->isValid('id', $itemId)) {
             $this->view->error('invalid id');
         }
 
-        $this->itemsDao->unmark($lastid);
+        $this->itemsDao->unmark($itemId);
 
         $this->view->jsonSuccess([
             'success' => true,
@@ -96,21 +92,18 @@ class Items {
      * starr item
      * json
      *
-     * @param Base $f3 fatfree base instance
-     * @param array $params query string parameters
+     * @param int $itemId id of an item to starr
      *
      * @return void
      */
-    public function starr(Base $f3, array $params) {
+    public function starr($itemId) {
         $this->authentication->needsLoggedIn();
 
-        $id = $params['item'];
-
-        if (!$this->itemsDao->isValid('id', $id)) {
+        if (!$this->itemsDao->isValid('id', $itemId)) {
             $this->view->error('invalid id');
         }
 
-        $this->itemsDao->starr($id);
+        $this->itemsDao->starr($itemId);
         $this->view->jsonSuccess([
             'success' => true,
         ]);
@@ -120,21 +113,18 @@ class Items {
      * unstarr item
      * json
      *
-     * @param Base $f3 fatfree base instance
-     * @param array $params query string parameters
+     * @param int $itemId id of an item to unstarr
      *
      * @return void
      */
-    public function unstarr(Base $f3, array $params) {
+    public function unstarr($itemId) {
         $this->authentication->needsLoggedIn();
 
-        $id = $params['item'];
-
-        if (!$this->itemsDao->isValid('id', $id)) {
+        if (!$this->itemsDao->isValid('id', $itemId)) {
             $this->view->error('invalid id');
         }
 
-        $this->itemsDao->unstarr($id);
+        $this->itemsDao->unstarr($itemId);
         $this->view->jsonSuccess([
             'success' => true,
         ]);

--- a/src/controllers/Items.php
+++ b/src/controllers/Items.php
@@ -2,7 +2,7 @@
 
 namespace controllers;
 
-use Base;
+use daos\ItemOptions;
 use helpers\Authentication;
 use helpers\View;
 
@@ -150,10 +150,7 @@ class Items {
         $this->authentication->needsLoggedInOrPublicMode();
 
         // parse params
-        $options = [];
-        if (count($_GET) > 0) {
-            $options = $_GET;
-        }
+        $options = ItemOptions::fromUser($_GET);
 
         // get items
         $items = $this->itemsDao->get($options);

--- a/src/controllers/Rss.php
+++ b/src/controllers/Rss.php
@@ -2,7 +2,7 @@
 
 namespace controllers;
 
-use Base;
+use daos\ItemOptions;
 use FeedWriter\RSS2;
 use helpers\Authentication;
 use helpers\Configuration;
@@ -46,12 +46,9 @@ class Rss {
     /**
      * rss feed
      *
-     * @param Base $f3 fatfree base instance
-     * @param array $params query string parameters
-     *
      * @return void
      */
-    public function rss(Base $f3, array $params) {
+    public function rss() {
         $this->authentication->needsLoggedInOrPublicMode();
 
         $this->feedWriter->setTitle($this->configuration->rssTitle);
@@ -64,18 +61,7 @@ class Rss {
         $lastSourceId = 0;
         $lastSourceName = '';
 
-        // set options
-        $options = [];
-        if (count($_GET) > 0) {
-            $options = $_GET;
-        }
-        $options['items'] = $this->configuration->rssMaxItems;
-        if (isset($params['tag'])) {
-            $options['tag'] = $params['tag'];
-        }
-        if (isset($params['type'])) {
-            $options['type'] = $params['type'];
-        }
+        $options = ItemOptions::fromUser($_GET);
 
         // get items
         $newestEntryDate = null;

--- a/src/controllers/Sources.php
+++ b/src/controllers/Sources.php
@@ -2,7 +2,6 @@
 
 namespace controllers;
 
-use Base;
 use helpers\Authentication;
 use helpers\SpoutLoader;
 use helpers\View;
@@ -111,15 +110,12 @@ class Sources {
      * delete source
      * json
      *
-     * @param Base $f3 fatfree base instance
-     * @param array $params query string parameters
+     * @param int $id ID of source to remove
      *
      * @return void
      */
-    public function remove(Base $f3, array $params) {
+    public function remove($id) {
         $this->authentication->needsLoggedIn();
-
-        $id = $params['id'];
 
         if (!$this->sourcesDao->isValid('id', $id)) {
             $this->view->error('invalid id given');

--- a/src/controllers/Sources/Update.php
+++ b/src/controllers/Sources/Update.php
@@ -2,7 +2,6 @@
 
 namespace controllers\Sources;
 
-use Base;
 use helpers\Authentication;
 use helpers\ContentLoader;
 
@@ -43,14 +42,11 @@ class Update {
      * update a single source
      * text
      *
-     * @param Base $f3 fatfree base instance
-     * @param array $params query string parameters
+     * @param int $id id of source to update
      *
      * @return void
      */
-    public function update(Base $f3, array $params) {
-        $id = $params['id'];
-
+    public function update($id) {
         // only allow access for localhost and authenticated users
         if (!$this->authentication->allowedToUpdate()) {
             exit('unallowed access');

--- a/src/controllers/Sources/Write.php
+++ b/src/controllers/Sources/Write.php
@@ -137,7 +137,7 @@ class Write {
         ];
 
         // only for selfoss ui (update stats in navigation)
-        if ($f3->ajax()) {
+        if ($this->view->isAjax()) {
             // get new tag list with updated count values
             $return['tags'] = $this->tagsDao->getWithUnread();
 

--- a/src/controllers/Sources/Write.php
+++ b/src/controllers/Sources/Write.php
@@ -2,7 +2,6 @@
 
 namespace controllers\Sources;
 
-use Base;
 use helpers\Authentication;
 use helpers\ContentLoader;
 use helpers\SpoutLoader;
@@ -40,21 +39,20 @@ class Write {
     }
 
     /**
-     * render spouts params
+     * Update source data or create a new source.
      * json
      *
-     * @param Base $f3 fatfree base instance
-     * @param array $params query string parameters
+     * @param ?int $id ID of source to update, or null to create a new one
      *
      * @return void
      */
-    public function write(Base $f3, array $params) {
+    public function write($id = null) {
         $this->authentication->needsLoggedIn();
 
         // read data
-        $headers = \F3::get('HEADERS');
-        $body = \F3::get('BODY');
-        if (isset($headers['Content-Type']) && strpos($headers['Content-Type'], 'application/json') === 0) {
+        $body = file_get_contents('php://input');
+        $contentType = $_SERVER['CONTENT_TYPE'] ?: '';
+        if (strpos($contentType, 'application/json') === 0) {
             $data = json_decode($body, true);
         } else {
             parse_str($body, $data);
@@ -91,7 +89,6 @@ class Write {
         unset($data['tags']);
 
         // check if source already exists
-        $id = isset($params['id']) ? $params['id'] : null;
         $sourceExists = $id !== null && $this->sourcesDao->isValid('id', $id);
 
         // load password value if not changed for spouts containing passwords

--- a/src/controllers/Tags.php
+++ b/src/controllers/Tags.php
@@ -2,7 +2,6 @@
 
 namespace controllers;
 
-use Base;
 use helpers\Authentication;
 use helpers\View;
 
@@ -66,19 +65,19 @@ class Tags {
      *
      * @return void
      */
-    public function color(Base $f3) {
+    public function color() {
         $this->authentication->needsLoggedIn();
 
         // read data
-        parse_str($f3->get('BODY'), $data);
+        parse_str(file_get_contents('php://input'), $data);
 
-        $tag = $data['tag'];
-        $color = $data['color'];
+        $tag = $data['tag'] ?: null;
+        $color = $data['color'] ?: null;
 
-        if (!isset($tag) || strlen(trim($tag)) === 0) {
+        if ($tag === null || strlen(trim($tag)) === 0) {
             $this->view->error('invalid or no tag given');
         }
-        if (!isset($color) || strlen(trim($color)) === 0) {
+        if ($color === null || strlen(trim($color)) === 0) {
             $this->view->error('invalid or no color given');
         }
 

--- a/src/daos/ItemOptions.php
+++ b/src/daos/ItemOptions.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace daos;
+
+use DateTime;
+
+/**
+ * Object holding parameters for querying items.
+ */
+class ItemOptions {
+    /** @var ?int @readonly */
+    public $offset = 0;
+
+    /** @var ?string @readonly */
+    public $search = null;
+
+    /** @var ?int maximum number of items to fetch from the database (unbounded) @readonly */
+    public $pageSize = null;
+
+    /** @var ?DateTime @readonly */
+    public $fromDatetime = null;
+
+    /** @var ?int @readonly */
+    public $fromId = null;
+
+    /** @var ?DateTime @readonly */
+    public $updatedSince = null;
+
+    /** @var ?string @readonly */
+    public $tag = null;
+
+    /** @var 'starred'|'unread'|null @readonly */
+    public $filter = null;
+
+    /** @var ?int @readonly */
+    public $source = null;
+
+    /** @var int[] @readonly */
+    public $extraIds = [];
+
+    /**
+     * Creates new ItemOptions object ensuring the values are proper types.
+     *
+     * @param array $data
+     *
+     * @return static
+     */
+    public static function fromUser($data) {
+        $options = new static();
+
+        if (isset($data['offset']) && is_numeric($data['offset'])) {
+            $options->offset = (int) $data['offset'];
+        }
+
+        if (isset($data['search']) && strlen(trim($data['search'])) > 0) {
+            $options->search = trim($data['search']);
+        }
+
+        if (isset($data['items']) && is_numeric($data['items'])) {
+            $options->pageSize = (int) $data['items'];
+        }
+
+        if (isset($data['fromDatetime']) && strlen($data['fromDatetime']) > 0) {
+            $options->fromDatetime = new \DateTime($data['fromDatetime']);
+        }
+
+        if (isset($data['fromId']) && is_numeric($data['fromId'])) {
+            $options->fromId = (int) $data['fromId'];
+        }
+
+        if (isset($data['updatedsince']) && strlen($data['updatedsince']) > 0) {
+            $options->updatedSince = new \DateTime($data['updatedsince']);
+        }
+
+        if (isset($data['tag']) && strlen(trim($data['tag'])) > 0) {
+            $options->tag = trim($data['tag']);
+        }
+
+        if (isset($data['type']) && in_array(trim($data['type']), ['starred', 'unread'], true)) {
+            $options->filter = trim($data['type']);
+        }
+
+        if (isset($data['source']) && is_numeric($data['source'])) {
+            $options->source = (int) $data['source'];
+        }
+
+        if (isset($data['extraIds']) && is_array($data['extraIds'])) {
+            $options->extraIds = $data['extraIds'];
+        }
+
+        return $options;
+    }
+}

--- a/src/daos/Items.php
+++ b/src/daos/Items.php
@@ -74,33 +74,11 @@ class Items {
     /**
      * returns items
      *
-     * @param mixed $options search, offset and filter params
+     * @param ItemOptions $options search, offset and filter params
      *
      * @return mixed items as array
      */
-    public function get($options = []) {
-        $options = array_merge(
-            [
-                'starred' => false,
-                'offset' => 0,
-                'search' => false,
-                'items' => $this->configuration->itemsPerpage,
-            ],
-            $options
-        );
-
-        if (isset($options['fromDatetime']) && strlen($options['fromDatetime']) > 0) {
-            $options['fromDatetime'] = new \DateTime($options['fromDatetime']);
-        } else {
-            unset($options['fromDatetime']);
-        }
-
-        if (isset($options['updatedsince']) && strlen($options['updatedsince']) > 0) {
-            $options['updatedsince'] = new \DateTime($options['updatedsince']);
-        } else {
-            unset($options['updatedsince']);
-        }
-
+    public function get(ItemOptions $options) {
         $items = $this->backend->get($options);
 
         // remove private posts with private tags
@@ -117,7 +95,7 @@ class Items {
         }
 
         // remove posts with hidden tags
-        if (!isset($options['tag']) || strlen($options['tag']) === 0) {
+        if ($options->tag !== null) {
             foreach ($items as $idx => $item) {
                 foreach ($item['tags'] as $tag) {
                     if (strpos(trim($tag), '#') === 0) {

--- a/src/daos/ItemsInterface.php
+++ b/src/daos/ItemsInterface.php
@@ -94,11 +94,11 @@ interface ItemsInterface {
     /**
      * returns items
      *
-     * @param mixed $options search, offset and filter params
+     * @param ItemOptions $options search, offset and filter params
      *
      * @return mixed items as array
      */
-    public function get($options = []);
+    public function get(ItemOptions $options);
 
     /**
      * returns whether more items for last given

--- a/src/daos/mysql/Items.php
+++ b/src/daos/mysql/Items.php
@@ -3,6 +3,7 @@
 namespace daos\mysql;
 
 use daos\DatabaseInterface;
+use daos\ItemOptions;
 use DateTime;
 use helpers\Configuration;
 use Monolog\Logger;
@@ -227,23 +228,24 @@ class Items implements \daos\ItemsInterface {
     /**
      * returns items
      *
-     * @param mixed $options search, offset and filter params
+     * @param ItemOptions $options search, offset and filter params
      *
      * @return mixed items as array
      */
-    public function get($options = []) {
+    public function get(ItemOptions $options) {
         $stmt = static::$stmt;
         $params = [];
         $where = [$stmt::bool(true)];
         $order = 'DESC';
+        $offset = $options->offset;
 
         // only starred
-        if (isset($options['type']) && $options['type'] === 'starred') {
+        if ($options->filter === 'starred') {
             $where[] = $stmt::isTrue('starred');
         }
 
         // only unread
-        elseif (isset($options['type']) && $options['type'] === 'unread') {
+        elseif ($options->filter === 'unread') {
             $where[] = $stmt::isTrue('unread');
             if ($this->configuration->unreadOrder === 'asc') {
                 $order = 'ASC';
@@ -251,46 +253,44 @@ class Items implements \daos\ItemsInterface {
         }
 
         // search
-        if (isset($options['search']) && strlen($options['search']) > 0) {
-            if (preg_match('#^/(?P<regex>.+)/$#', $options['search'], $matches)) {
+        if ($options->search !== null) {
+            if (preg_match('#^/(?P<regex>.+)/$#', $options->search, $matches)) {
                 $params[':search'] = $params[':search2'] = $params[':search3'] = [$matches['regex'], \PDO::PARAM_STR];
                 $where[] = $stmt::exprOr($stmt::matchesRegex('items.title', ':search'), $stmt::matchesRegex('items.content', ':search2'), $stmt::matchesRegex('sources.title', ':search3'));
             } else {
-                $search = implode('%', \helpers\Search::splitTerms($options['search']));
+                $search = implode('%', \helpers\Search::splitTerms($options->search));
                 $params[':search'] = $params[':search2'] = $params[':search3'] = ['%' . $search . '%', \PDO::PARAM_STR];
                 $where[] = '(items.title LIKE :search OR items.content LIKE :search2 OR sources.title LIKE :search3) ';
             }
         }
 
         // tag filter
-        if (isset($options['tag']) && strlen($options['tag']) > 0) {
-            $params[':tag'] = $options['tag'];
+        if ($options->tag !== null) {
+            $params[':tag'] = $options->tag;
             $where[] = 'items.source=sources.id';
             $where[] = $stmt::csvRowMatches('sources.tags', ':tag');
         }
         // source filter
-        elseif (isset($options['source']) && strlen($options['source']) > 0) {
-            $params[':source'] = [$options['source'], \PDO::PARAM_INT];
+        elseif ($options->source !== null) {
+            $params[':source'] = [$options->source, \PDO::PARAM_INT];
             $where[] = 'items.source=:source ';
         }
 
         // update time filter
-        if (isset($options['updatedsince'])) {
+        if ($options->updatedSince !== null) {
             $params[':updatedsince'] = [
-                $stmt::datetime($options['updatedsince']), \PDO::PARAM_STR,
+                $stmt::datetime($options->updatedSince), \PDO::PARAM_STR,
             ];
             $where[] = 'items.updatetime > :updatedsince ';
         }
 
         // seek pagination (alternative to offset)
-        if (isset($options['fromDatetime'])
-            && isset($options['fromId'])
-            && is_numeric($options['fromId'])) {
+        if ($options->fromDatetime !== null && $options->fromId !== null) {
             // discard offset as it makes no sense to mix offset pagination
             // with seek pagination.
-            $options['offset'] = 0;
+            $offset = 0;
 
-            $offset_from_datetime_sql = $stmt::datetime($options['fromDatetime']);
+            $offset_from_datetime_sql = $stmt::datetime($options->fromDatetime);
             $params[':offset_from_datetime'] = [
                 $offset_from_datetime_sql, \PDO::PARAM_STR,
             ];
@@ -298,7 +298,7 @@ class Items implements \daos\ItemsInterface {
                 $offset_from_datetime_sql, \PDO::PARAM_STR,
             ];
             $params[':offset_from_id'] = [
-                $options['fromId'], \PDO::PARAM_INT,
+                $options->fromId, \PDO::PARAM_INT,
             ];
             $ltgt = null;
             if ($order === 'ASC') {
@@ -315,37 +315,25 @@ class Items implements \daos\ItemsInterface {
                         )";
         }
 
-        $where_ids = '';
+        $where_ids = null;
         // extra ids to include in stream
-        if (isset($options['extraIds'])
-            && is_array($options['extraIds'])
-            && count($options['extraIds']) > 0
+        if (count($options->extraIds) > 0
             // limit the query to a sensible max
-            && count($options['extraIds']) <= $this->configuration->itemsPerpage) {
-            $extra_ids_stmt = $stmt::intRowMatches('items.id', $options['extraIds']);
-            if ($extra_ids_stmt !== null) {
-                $where_ids = $extra_ids_stmt;
-            }
+            && count($options->extraIds) <= $this->configuration->itemsPerpage) {
+            $where_ids = $stmt::intRowMatches('items.id', $options->extraIds);
         }
 
         // finalize items filter
         $where_sql = implode(' AND ', $where);
 
         // set limit
-        if (!isset($options['items']) || !is_numeric($options['items']) || $options['items'] > 200) {
-            $options['items'] = $this->configuration->itemsPerpage;
-        }
-
-        // set offset
-        if (!isset($options['offset']) || !is_numeric($options['offset'])) {
-            $options['offset'] = 0;
-        }
+        $pageSize = $options->pageSize === null ? $this->configuration->itemsPerpage : min($options->pageSize, max(200, $this->configuration->itemsPerpage));
 
         // first check whether more items are available
         $result = $this->database->exec('SELECT items.id
                    FROM ' . $this->configuration->dbPrefix . 'items AS items, ' . $this->configuration->dbPrefix . 'sources AS sources
                    WHERE items.source=sources.id AND ' . $where_sql . '
-                   LIMIT 1 OFFSET ' . ($options['offset'] + $options['items']), $params);
+                   LIMIT 1 OFFSET ' . ($offset + $pageSize), $params);
         $this->hasMore = count($result) > 0;
 
         // get items from database
@@ -355,7 +343,7 @@ class Items implements \daos\ItemsInterface {
             WHERE items.source=sources.id AND';
         $order_sql = 'ORDER BY items.datetime ' . $order . ', items.id ' . $order;
 
-        if ($where_ids !== '') {
+        if ($where_ids !== null) {
             // This UNION is required for the extra explicitely requested items
             // to be included whether or not they would have been excluded by
             // seek, filter, offset rules.
@@ -365,13 +353,13 @@ class Items implements \daos\ItemsInterface {
             // complaining about 'order by clause should come after union not
             // before'.
             $query = "SELECT * FROM (
-                        SELECT * FROM ($select $where_sql $order_sql LIMIT " . $options['items'] . ' OFFSET ' . $options['offset'] . ") AS entries
+                        SELECT * FROM ($select $where_sql $order_sql LIMIT " . $pageSize . ' OFFSET ' . $offset . ") AS entries
                       UNION
                         $select $where_ids
                       ) AS items
                       $order_sql";
         } else {
-            $query = "$select $where_sql $order_sql LIMIT " . $options['items'] . ' OFFSET ' . $options['offset'];
+            $query = "$select $where_sql $order_sql LIMIT " . $pageSize . ' OFFSET ' . $offset;
         }
 
         return $stmt::ensureRowTypes($this->database->exec($query, $params), [

--- a/src/helpers/Authentication.php
+++ b/src/helpers/Authentication.php
@@ -150,7 +150,7 @@ class Authentication {
      */
     public function needsLoggedInOrPublicMode() {
         if ($this->isLoggedin() !== true && !$this->configuration->public) {
-            \F3::error(403);
+            $this->forbidden();
         }
     }
 
@@ -161,8 +161,19 @@ class Authentication {
      */
     public function needsLoggedIn() {
         if ($this->isLoggedin() !== true) {
-            \F3::error(403);
+            $this->forbidden();
         }
+    }
+
+    /**
+     * send 403 if not logged in
+     *
+     * @return void
+     */
+    public function forbidden() {
+        header('HTTP/1.0 403 Forbidden');
+        echo 'Access forbidden!';
+        exit;
     }
 
     /**

--- a/src/helpers/ContentLoader.php
+++ b/src/helpers/ContentLoader.php
@@ -207,10 +207,7 @@ class ContentLoader {
             }
 
             // sanitize title
-            $title = $this->sanitizeField($item->getTitle());
-            if (strlen(trim($title)) === 0) {
-                $title = '[' . \F3::get('lang_no_title') . ']';
-            }
+            $title = trim($this->sanitizeField($item->getTitle()));
 
             // Check sanitized title against filter
             if ($this->filter($source, $title, $content) === false) {

--- a/src/helpers/View.php
+++ b/src/helpers/View.php
@@ -56,7 +56,10 @@ class View {
                 $subdir = '/' . preg_replace('/\/[^\/]+$/', '', $_SERVER['PHP_SELF']);
                 $host = $_SERVER['HTTP_X_FORWARDED_SERVER'];
             } else {
-                $subdir = \F3::get('BASE');
+                $subdir = '';
+                if (PHP_SAPI !== 'cli') {
+                    $subdir = rtrim(strtr(dirname($_SERVER['SCRIPT_NAME']), '\\', '/'), '/');
+                }
                 $host = $_SERVER['SERVER_NAME'];
             }
 

--- a/src/helpers/View.php
+++ b/src/helpers/View.php
@@ -78,6 +78,17 @@ class View {
     }
 
     /**
+     * Tests whether the current request was made using AJAX.
+     *
+     * (The JavaScript AJAX library needs to set the header.)
+     *
+     * @return bool
+     */
+    public function isAjax() {
+        return isset($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest';
+    }
+
+    /**
      * send error message
      *
      * @param string $message


### PR DESCRIPTION
- Do not use AJAX detection from F3
- Do not do localization on the server
- daos\items: Use value object for query options
- Do not use F3 for base URI detection
- Do not use F3 for HTTP errors
- **Switch to bramus\router for routing**

We still need to get rid of Database and error logging. Unfortunately “fat-free” will destroy error handling if even a sliver remains so Database will have to go first.
