### PR TITLE
client: Add route for adding RSS sources

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 - Added option `reading_speed_wpm` for showing estimated reading time. ([#1232](https://github.com/fossar/selfoss/pull/1232))
 - Added option `db_socket` for connecting to MySQL database through UNIX domain. ([#1284](https://github.com/fossar/selfoss/pull/1284))
 - Search query is now part of URL. ([#1216](https://github.com/fossar/selfoss/pull/1216))
+- A page that will pre-fill a form for adding a source with URL has been added. You can find it on `https://yourselfossurl.com/manage/sources/add?url=some-feed-url`. ([#1310](https://github.com/fossar/selfoss/pull/1310), [#254](https://github.com/fossar/selfoss/issues/254))
 - Search will be carried out using regular expressions when the search query is wrapped in forward slashes, e.g. `/regex/`. The expression syntax is database specific. ([#1205](https://github.com/fossar/selfoss/pull/1205))
 - YouTube spout now supports following playlists. ([#1260](https://github.com/fossar/selfoss/pull/1260))
 - Confirmation is now required when leaving the setting page with unsaved source changes. ([#1300](https://github.com/fossar/selfoss/pull/1300))

--- a/assets/js/templates/Source.jsx
+++ b/assets/js/templates/Source.jsx
@@ -451,7 +451,8 @@ function SourceEditForm({
                                                 spoutParam,
                                                 sourceErrors,
                                                 sourceId,
-                                                setEditedSource
+                                                setEditedSource,
+                                                setDirty,
                                             }}
                                         />
                                     )

--- a/assets/js/templates/SourceParam.jsx
+++ b/assets/js/templates/SourceParam.jsx
@@ -8,10 +8,12 @@ export default function SourceParam({
     params = {},
     sourceErrors,
     sourceId,
-    setEditedSource
+    setEditedSource,
+    setDirty,
 }) {
     const updateSourceParam = React.useCallback(
         (event) => {
+            setDirty(true);
             setEditedSource(({ params, ...restSource }) => ({
                 ...restSource,
                 params: {
@@ -20,7 +22,7 @@ export default function SourceParam({
                 }
             }));
         },
-        [setEditedSource, spoutParamName]
+        [setEditedSource, setDirty, spoutParamName]
     );
 
     const updateSourceParamBool = React.useCallback(
@@ -117,4 +119,5 @@ SourceParam.propTypes = {
     sourceErrors: PropTypes.objectOf(PropTypes.string).isRequired,
     sourceId: PropTypes.number.isRequired,
     setEditedSource: PropTypes.func.isRequired,
+    setDirty: PropTypes.func.isRequired,
 };

--- a/assets/js/templates/SourcesPage.jsx
+++ b/assets/js/templates/SourcesPage.jsx
@@ -26,19 +26,18 @@ function handleAddSource({
         event.preventDefault();
     }
 
-    // add new source
+    // Add new empty source.
+    setSources((sources) => [{ id: 'new-' + rand(), ...extraInitialData }, ...sources]);
+
+    // Refresh the spout datea
     sourceRequests
         .getSpouts()
         .then(({ spouts }) => {
             // Update spout data.
             setSpouts(spouts);
-            // Add new empty source.
-            setSources((sources) => [{ id: 'new-' + rand(), ...extraInitialData }, ...sources]);
         })
-        .catch((error) => {
-            selfoss.app.showError(
-                selfoss.app._('error_add_source') + ' ' + error.message
-            );
+        .catch(() => {
+            console.error('Unable to update spouts, falling back to previously fetched list.');
         });
 }
 

--- a/index.php
+++ b/index.php
@@ -152,7 +152,7 @@ $router->get('/opmlexport', function() use ($dice) {
 });
 
 // Client side routes need to be directed to index.html.
-$router->get('/sign/in|/manage/sources|/(newest|unread|starred)(/(all|tag-[^/]+|source-[0-9]+)(/[0-9]+)?)?', function() use ($dice) {
+$router->get('/sign/in|/manage/sources(/add)?|/(newest|unread|starred)(/(all|tag-[^/]+|source-[0-9]+)(/[0-9]+)?)?', function() use ($dice) {
     // html
     $dice->create(controllers\Index::class)->home();
 });


### PR DESCRIPTION
Visiting `/manage/sources/add?url=foo` will load the settings page, open the “new source” form and pre-fill the URL specified in the query string parameter. For now, only URL is customizable.

Fixes: https://github.com/fossar/selfoss/issues/254
