### PR TITLE
client: Add tag autocomplete

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 # selfoss news
 ## 2.20 – unreleased
 
+### New features
+- Tags are now autocompleted when editing a new source. ([#1311](https://github.com/fossar/selfoss/pull/1311), [#669](https://github.com/fossar/selfoss/issues/669))
+
 ### Bug fixes
 - Configuration parser was changed to *raw* method, which relaxes the requirement to quote option values containing special characters in `config.ini`. ([#1371](https://github.com/fossar/selfoss/issues/1371))
 

--- a/assets/js/templates/App.jsx
+++ b/assets/js/templates/App.jsx
@@ -265,7 +265,9 @@ function PureApp({
                                     )}
                                 </Route>
                                 <Route path="/manage/sources">
-                                    <SourcesPage />
+                                    <SourcesPage
+                                        tags={tags}
+                                    />
                                 </Route>
                                 <Route path="*">
                                     <NotFound />

--- a/assets/js/templates/Source.jsx
+++ b/assets/js/templates/Source.jsx
@@ -195,10 +195,20 @@ function handleEdit({ event, source, tagInfo, setEditedSource }) {
 
     const { id, title, tags, filter, spout, params } = source;
 
+    const newTags =
+        tags
+            ? tags.map(unescape).map((name) => ({
+                id: tagInfo[name]?.id,
+                name,
+                color: tagInfo[name]?.color,
+                foregroundColor: tagInfo[name]?.foregroundColor
+            }))
+            : [];
+
     setEditedSource({
         id,
         title: title ? unescape(title) : '',
-        tags: tags ? tags.map(unescape).map((name) => ({ id: tagInfo[name]?.id, name })) : [],
+        tags: newTags,
         filter,
         spout,
         params
@@ -264,6 +274,32 @@ function daysAgo(date) {
 
     return Math.floor((today - old) / MS_PER_DAY);
 }
+
+
+function Tag({ classNames, removeButtonText, onDelete, tag }) {
+    return (
+        <button
+            type="button"
+            className={classNames.selectedTag}
+            title={removeButtonText}
+            onClick={onDelete}
+            style={{
+                backgroundColor: tag.color,
+                color: tag.foregroundColor,
+            }}
+        >
+            <span className={classNames.selectedTagName}>{tag.name}</span>
+        </button>
+    );
+}
+
+Tag.propTypes = {
+    classNames: PropTypes.object.isRequired,
+    removeButtonText: PropTypes.string.isRequired,
+    onDelete: PropTypes.func.isRequired,
+    tag: PropTypes.object.isRequired,
+};
+
 
 const reactTagsClassNames = {
     root: 'react-tags',
@@ -499,6 +535,7 @@ function SourceEditForm({
                         removeButtonText={_('source_tag_remove_button_label')}
                         classNames={reactTagsClassNames}
                         delimiters={['Enter', 'Tab', ',']}
+                        tagComponent={Tag}
                     />
                     {sourceErrors['tags'] ? (
                         <span className="error">{sourceErrors['tags']}</span>

--- a/assets/js/templates/Source.jsx
+++ b/assets/js/templates/Source.jsx
@@ -201,7 +201,6 @@ function handleEdit({ event, source, tagInfo, setEditedSource }) {
                 id: tagInfo[name]?.id,
                 name,
                 color: tagInfo[name]?.color,
-                foregroundColor: tagInfo[name]?.foregroundColor
             }))
             : [];
 
@@ -283,11 +282,14 @@ function Tag({ classNames, removeButtonText, onDelete, tag }) {
             className={classNames.selectedTag}
             title={removeButtonText}
             onClick={onDelete}
-            style={{
-                backgroundColor: tag.color,
-                color: tag.foregroundColor,
-            }}
         >
+            <span
+                className="color"
+                style={{
+                    backgroundColor: tag.color,
+                }}
+            />
+            {' '}
             <span className={classNames.selectedTagName}>{tag.name}</span>
         </button>
     );

--- a/assets/js/templates/Source.jsx
+++ b/assets/js/templates/Source.jsx
@@ -290,28 +290,31 @@ ColorBox.propTypes = {
     color: nullable(PropTypes.string).isRequired,
 };
 
+function mkTag(tagInfo) {
+    function Tag({ classNames, removeButtonText, onDelete, tag }) {
+        return (
+            <button
+                type="button"
+                className={classNames.selectedTag}
+                title={removeButtonText}
+                onClick={onDelete}
+            >
+                <ColorBox color={tagInfo[tag.name]?.color ?? null} />
+                {' '}
+                <span className={classNames.selectedTagName}>{tag.name}</span>
+            </button>
+        );
+    }
 
-function Tag({ classNames, removeButtonText, onDelete, tag }) {
-    return (
-        <button
-            type="button"
-            className={classNames.selectedTag}
-            title={removeButtonText}
-            onClick={onDelete}
-        >
-            <ColorBox color={tag.color ?? null} />
-            {' '}
-            <span className={classNames.selectedTagName}>{tag.name}</span>
-        </button>
-    );
+    Tag.propTypes = {
+        classNames: PropTypes.object.isRequired,
+        removeButtonText: PropTypes.string.isRequired,
+        onDelete: PropTypes.func.isRequired,
+        tag: PropTypes.object.isRequired,
+    };
+
+    return Tag;
 }
-
-Tag.propTypes = {
-    classNames: PropTypes.object.isRequired,
-    removeButtonText: PropTypes.string.isRequired,
-    onDelete: PropTypes.func.isRequired,
-    tag: PropTypes.object.isRequired,
-};
 
 
 const reactTagsClassNames = {
@@ -508,6 +511,8 @@ function SourceEditForm({
 
     const reactTags = useRef();
 
+    const tagComponent = useMemo(() => mkTag(tagInfo), [tagInfo]);
+
     return (
         <form>
             <ul className="source-edit-form">
@@ -552,7 +557,7 @@ function SourceEditForm({
                         removeButtonText={_('source_tag_remove_button_label')}
                         classNames={reactTagsClassNames}
                         delimiters={['Enter', 'Tab', ',']}
-                        tagComponent={Tag}
+                        tagComponent={tagComponent}
                     />
                     {sourceErrors['tags'] ? (
                         <span className="error">{sourceErrors['tags']}</span>

--- a/assets/js/templates/Source.jsx
+++ b/assets/js/templates/Source.jsx
@@ -275,6 +275,22 @@ function daysAgo(date) {
 }
 
 
+function ColorBox({ color }) {
+    return (
+        <span
+            className="color"
+            style={{
+                backgroundColor: color,
+            }}
+        />
+    );
+}
+
+ColorBox.propTypes = {
+    color: nullable(PropTypes.string).isRequired,
+};
+
+
 function Tag({ classNames, removeButtonText, onDelete, tag }) {
     return (
         <button
@@ -283,12 +299,7 @@ function Tag({ classNames, removeButtonText, onDelete, tag }) {
             title={removeButtonText}
             onClick={onDelete}
         >
-            <span
-                className="color"
-                style={{
-                    backgroundColor: tag.color,
-                }}
-            />
+            <ColorBox color={tag.color ?? null} />
             {' '}
             <span className={classNames.selectedTagName}>{tag.name}</span>
         </button>
@@ -450,7 +461,11 @@ function SourceEditForm({
     );
 
     const tagSuggestions = useMemo(
-        () => Object.entries(tagInfo).map(([name, { id }]) => ({ id, name })),
+        () => Object.entries(tagInfo).map(([name, { id, color }]) => ({
+            id,
+            name,
+            prefix: <ColorBox color={color ?? null} />
+        })),
         [tagInfo]
     );
 

--- a/assets/js/templates/Source.jsx
+++ b/assets/js/templates/Source.jsx
@@ -552,6 +552,7 @@ function SourceEditForm({
                         onDelete={tagsOnDelete}
                         onAddition={tagsOnAddition}
                         allowNew={true}
+                        addOnBlur={true}
                         minQueryLength={1}
                         placeholderText={_('source_tags_placeholder')}
                         removeButtonText={_('source_tag_remove_button_label')}

--- a/assets/js/templates/SourcesPage.jsx
+++ b/assets/js/templates/SourcesPage.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { useMemo } from 'react';
 import { Prompt } from 'react-router';
@@ -90,9 +91,26 @@ function loadSources({ abortController, location, setSpouts, setSources, setLoad
     });
 }
 
-export default function SourcesPage() {
+export default function SourcesPage({ tags }) {
     const [spouts, setSpouts] = React.useState([]);
     const [sources, setSources] = React.useState([]);
+    const tagInfo = useMemo(
+        () => {
+            let maxTagId = 1;
+            let info = {};
+
+            tags.forEach(({ tag }) => {
+                if (typeof info[tag] === 'undefined') {
+                    info[tag] = {
+                        id: maxTagId++,
+                    };
+                }
+            });
+
+            return info;
+        },
+        [tags]
+    );
 
     const [loadingState, setLoadingState] = React.useState(LoadingState.INITIAL);
 
@@ -104,6 +122,11 @@ export default function SourcesPage() {
 
     React.useEffect(() => {
         const abortController = new AbortController();
+
+        if (selfoss.app.state.tags.length === 0) {
+            // Ensure tags are loaded.
+            selfoss.reloadTags();
+        }
 
         loadSources({ abortController, location, setSpouts, setSources, setLoadingState })
             .then(() => {
@@ -183,7 +206,7 @@ export default function SourcesPage() {
                             <Source
                                 key={source.id}
                                 dirty={dirtySources[source.id] ?? false}
-                                {...{ source, setSources, spouts, setSpouts, setDirtySources }}
+                                {...{ source, setSources, spouts, setSpouts, setDirtySources, tagInfo }}
                             />
                         ))}
                     </ul>
@@ -197,3 +220,7 @@ export default function SourcesPage() {
         </React.Fragment>
     );
 }
+
+SourcesPage.propTypes = {
+    tags: PropTypes.array.isRequired,
+};

--- a/assets/js/templates/SourcesPage.jsx
+++ b/assets/js/templates/SourcesPage.jsx
@@ -92,26 +92,6 @@ function loadSources({ abortController, location, setSpouts, setSources, setLoad
 }
 
 
-/**
- * Get dark OR bright color depending the color contrast.
- *
- * @param {string} color color (hex) value
- * @param {string} darkColor dark color value
- * @param {string} brightColor bright color value
- *
- * @return {string} dark OR bright color value
- *
- * @see https://24ways.org/2010/calculating-color-contrast/
- */
-function getContrastYiq(hexcolor, darkColor = '#555', brightColor = '#eee') {
-    const r = parseInt(hexcolor.substr(1 + 0, 2), 16);
-    const g = parseInt(hexcolor.substr(1 + 2, 2), 16);
-    const b = parseInt(hexcolor.substr(1 + 4, 2), 16);
-    const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
-    return (yiq >= 128) ? darkColor : brightColor;
-}
-
-
 export default function SourcesPage({ tags }) {
     const [spouts, setSpouts] = React.useState([]);
     const [sources, setSources] = React.useState([]);
@@ -125,7 +105,6 @@ export default function SourcesPage({ tags }) {
                     info[tag] = {
                         id: maxTagId++,
                         color,
-                        foregroundColor: getContrastYiq(color.substr()),
                     };
                 }
             });

--- a/assets/js/templates/SourcesPage.jsx
+++ b/assets/js/templates/SourcesPage.jsx
@@ -91,6 +91,27 @@ function loadSources({ abortController, location, setSpouts, setSources, setLoad
     });
 }
 
+
+/**
+ * Get dark OR bright color depending the color contrast.
+ *
+ * @param {string} color color (hex) value
+ * @param {string} darkColor dark color value
+ * @param {string} brightColor bright color value
+ *
+ * @return {string} dark OR bright color value
+ *
+ * @see https://24ways.org/2010/calculating-color-contrast/
+ */
+function getContrastYiq(hexcolor, darkColor = '#555', brightColor = '#eee') {
+    const r = parseInt(hexcolor.substr(1 + 0, 2), 16);
+    const g = parseInt(hexcolor.substr(1 + 2, 2), 16);
+    const b = parseInt(hexcolor.substr(1 + 4, 2), 16);
+    const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
+    return (yiq >= 128) ? darkColor : brightColor;
+}
+
+
 export default function SourcesPage({ tags }) {
     const [spouts, setSpouts] = React.useState([]);
     const [sources, setSources] = React.useState([]);
@@ -99,10 +120,12 @@ export default function SourcesPage({ tags }) {
             let maxTagId = 1;
             let info = {};
 
-            tags.forEach(({ tag }) => {
+            tags.forEach(({ tag, color }) => {
                 if (typeof info[tag] === 'undefined') {
                     info[tag] = {
                         id: maxTagId++,
+                        color,
+                        foregroundColor: getContrastYiq(color.substr()),
                     };
                 }
             });

--- a/assets/locale/cs.json
+++ b/assets/locale/cs.json
@@ -43,6 +43,8 @@
   "lang_source_title": "Název",
   "lang_source_autotitle_hint": "Pro automatické vyplnění ponechte prázdné",
   "lang_source_tags": "Štítky",
+  "lang_source_tags_placeholder": "Přidat nový štítek",
+  "lang_source_tag_remove_button_label": "Klikněte pro odstranění štítku",
   "lang_source_pwd_placeholder": "Beze změny",
   "lang_source_comma": "Oddělené čárkou",
   "lang_source_select": "Vyberte prosím zdroj",

--- a/assets/locale/en.json
+++ b/assets/locale/en.json
@@ -55,6 +55,8 @@
   "lang_source_title": "Title",
   "lang_source_autotitle_hint": "Leave empty to fetch title",
   "lang_source_tags": "Tags",
+  "lang_source_tags_placeholder": "Add new tag",
+  "lang_source_tag_remove_button_label": "Click to remove tag",
   "lang_source_pwd_placeholder": "Not changed",
   "lang_source_comma": "Comma separated",
   "lang_source_select": "Please select source",

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -29,6 +29,7 @@
         "react-aria-menubutton": "^7.0.3",
         "react-dom": "^17.0.1",
         "react-router-dom": "^5.2.0",
+        "react-tag-autocomplete": "^6.3.0",
         "reset-css": "^5.0.1",
         "rooks": "^7.1.1",
         "tinykeys": "^1.1.1",
@@ -5648,6 +5649,19 @@
         "react": ">=15"
       }
     },
+    "node_modules/react-tag-autocomplete": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-tag-autocomplete/-/react-tag-autocomplete-6.3.0.tgz",
+      "integrity": "sha512-MUBVUFh5eOqshUm5NM20qp7zXk8TzSiKO4GoktlFzBLIOLs356npaMKtL02bm0nFV2f1zInUrXn1fq6+i5YX0w==",
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.5.0",
+        "react": "^16.5.0 || ^17.0.0",
+        "react-dom": "^16.5.0 || ^17.0.0"
+      }
+    },
     "node_modules/read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -10842,6 +10856,12 @@
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
       }
+    },
+    "react-tag-autocomplete": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-tag-autocomplete/-/react-tag-autocomplete-6.3.0.tgz",
+      "integrity": "sha512-MUBVUFh5eOqshUm5NM20qp7zXk8TzSiKO4GoktlFzBLIOLs356npaMKtL02bm0nFV2f1zInUrXn1fq6+i5YX0w==",
+      "requires": {}
     },
     "read-pkg": {
       "version": "5.2.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -24,6 +24,7 @@
     "react-aria-menubutton": "^7.0.3",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",
+    "react-tag-autocomplete": "^6.3.0",
     "reset-css": "^5.0.1",
     "rooks": "^7.1.1",
     "tinykeys": "^1.1.1",

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -16,6 +16,7 @@ $text-color: black;
     // https://github.com/sass/libsass/issues/2621
     --primary: #{$primary};
     --primary-contrast: #ffffff;
+    --text-color-for-primary: #eeeeec;
     --primary-highlight: #{$primary-highlight};
     --primary-highlight-shadow: #{$primary-highlight-shadow};
     --text-color: #{$text-color};
@@ -30,6 +31,7 @@ $search-entry-width: 20rem;
 $search-button-width: 30px;
 
 @import 'color-chooser';
+@import 'tags';
 
 html,
 body {
@@ -47,7 +49,8 @@ button {
 }
 
 select,
-input {
+input,
+.react-tags {
     border: solid 1px #cccccc;
     background: var(--background-color);
     color: var(--text-color);
@@ -57,7 +60,8 @@ input {
 }
 
 select:focus,
-input:focus {
+input:not(.react-tags-search-input):focus,
+.react-tags.is-focused {
     color: color.mix($text-color, $primary, 50%);
     border-color: var(--primary);
     outline: 0;
@@ -719,8 +723,10 @@ span.offline-count.diff {
 
 /* sources */
 
-.source input {
+.source input,
+.react-tags {
     width: 60%;
+    box-sizing: border-box;
 }
 
 .source-title {

--- a/assets/styles/tags.scss
+++ b/assets/styles/tags.scss
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+// Taken with minor changes from:
+// https://github.com/i-like-robots/react-tags/blob/9ac82a9879f53d46759dbd559d8b0a99bcd376ae/example/styles.css
+// © 2015 Prakhar Srivastav
+// © 2016–2018 Matt Hinchliffe
+
+/**
+ * <div class="react-tags">
+ *   <div class="react-tags-selected">
+ *     <button class="react-tags-selected-tag">
+ *       <span class="react-tags-selected-tag-name" />
+ *     </button>
+ *   </div>
+ *   <div class="react-tags-search">
+ *     <div class="react-tags-search-wrapper">
+ *       <input class="react-tags-search-input" />
+ *       <div />
+ *     </div>
+ *     <div class="react-tags-suggestions">
+ *       <ul>
+ *         <li class="is-active">
+ *           <mark />
+ *         </li>
+ *         <li class="is-disabled">
+ *           <mark />
+ *         </li>
+ *       </ul>
+ *     </div>
+ *   </div>
+ */
+
+.react-tags {
+    position: relative;
+    display: inline-block;
+    padding: 3px 0 0 3px;
+
+    /* shared font styles */
+    font-size: 1em;
+    line-height: 1.2;
+
+    /* clicking anywhere will focus the input */
+    cursor: text;
+}
+
+.react-tags-selected {
+    display: inline;
+}
+
+.react-tags-selected-tag {
+    display: inline-block;
+    box-sizing: border-box;
+    margin: 3px;
+    padding: 3px 4px;
+    border: 1px solid #d1d1d1;
+    border-radius: 4px;
+    background: #f1f1f1;
+    color: #1f1f1f;
+    cursor: pointer;
+
+    /* match the font styles */
+    font-size: inherit;
+    line-height: inherit;
+
+    &:hover,
+    &:focus {
+        border-color: #b1b1b1;
+    }
+}
+
+.react-tags-selected-tag::after {
+    content: '✕';
+    color: #aaaaaa;
+    margin-left: 4px;
+}
+
+.react-tags-search {
+    display: inline-block;
+
+    /* match tag layout */
+    padding: 4px 2px;
+    margin: 3px 0;
+
+    /* prevent autoresize overflowing the container */
+    max-width: 100%;
+}
+
+@media screen and (min-width: 30em) {
+    .react-tags-search {
+        /* this will become the offsetParent for suggestions */
+        position: relative;
+    }
+}
+
+.react-tags-search-input {
+    /* prevent autoresize overflowing the container */
+    max-width: 100%;
+
+    /* remove styles and layout from this element */
+    margin: 0;
+    padding: 0;
+    border: 0;
+    outline: none;
+
+    /* match the font styles */
+    font-size: inherit;
+    line-height: inherit;
+}
+
+.react-tags-suggestions {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    width: 100%;
+}
+
+@media screen and (min-width: 30em) {
+    .react-tags-suggestions {
+        width: 240px;
+    }
+}
+
+.react-tags-suggestions ul {
+    margin: 4px -1px;
+    padding: 0;
+    list-style: none;
+    background: var(--background-color);
+    color: var(--text-color);
+    border: 1px solid #d1d1d1;
+    border-radius: 2px;
+    box-shadow: 0 2px 3px rgb(0 0 0 / 20%);
+}
+
+.react-tags-suggestions li {
+    border-bottom: 1px solid #dddddd;
+    padding: 3px 4px;
+}
+
+.react-tags-suggestions li mark {
+    text-decoration: underline;
+    background: none;
+    font-weight: 600;
+}
+
+.react-tags-suggestions li.is-active {
+    background: var(--primary-highlight);
+    color: var(--text-color);
+}
+
+.react-tags-suggestions li:hover {
+    cursor: pointer;
+    background: var(--primary);
+    color: var(--text-color-for-primary);
+}
+
+.react-tags-suggestions li.is-disabled {
+    opacity: 0.5;
+    cursor: auto;
+}

--- a/assets/styles/tags.scss
+++ b/assets/styles/tags.scss
@@ -46,6 +46,13 @@
     display: inline;
 }
 
+.react-tags .color {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+}
+
 .react-tags-selected-tag {
     display: inline-block;
     box-sizing: border-box;


### PR DESCRIPTION
Fixes: https://github.com/fossar/selfoss/issues/669

- [x] Show colours for tags when editing starts
- [x] Show colours in autocomplete
- [ ] Add copy button
- [x] Newly added tags lack colours https://github.com/i-like-robots/react-tags/pull/260
- [ ] Auto assign colours for newly created tags
- [ ] Allow changing tag colours
- [ ] handle tags with HTML special characters like “ham & eggs” or “<3” correctly
- [ ] Add support for new tag message suffix https://github.com/i-like-robots/react-tags/issues/262

![tag-autocompletion](https://user-images.githubusercontent.com/705123/150525008-d71a05fd-6164-453d-bb2a-2ce0f0cfc220.png)
