### PR TITLE
spouts: Use Iterator for items internally

### DIFF
--- a/src/helpers/ItemsIterator.php
+++ b/src/helpers/ItemsIterator.php
@@ -6,20 +6,20 @@ namespace helpers;
  * Allow iterating spout’s items directly through the spout object.
  */
 trait ItemsIterator {
-    /** @var ?array current fetched items */
+    /** @var ?\Iterator current fetched items */
     protected $items = null;
 
     #[\ReturnTypeWillChange]
     public function rewind() {
         if ($this->items !== null) {
-            reset($this->items);
+            $this->items->rewind();
         }
     }
 
     /**
      * receive current item
      *
-     * @return self|false current item
+     * @return self|null current item
      */
     #[\ReturnTypeWillChange]
     public function current() {
@@ -27,35 +27,33 @@ trait ItemsIterator {
             return $this;
         }
 
-        return false;
+        return null;
     }
 
     /**
      * receive key of current item
      *
-     * @return mixed key of current item
+     * @return mixed|null key of current item
      */
     #[\ReturnTypeWillChange]
     public function key() {
         if ($this->items !== null) {
-            return key($this->items);
+            return $this->items->key();
         }
 
-        return false;
+        return null;
     }
 
     /**
      * select next item
      *
-     * @return self next item
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function next() {
         if ($this->items !== null) {
-            next($this->items);
+            $this->items->next();
         }
-
-        return $this;
     }
 
     /**
@@ -66,7 +64,7 @@ trait ItemsIterator {
     #[\ReturnTypeWillChange]
     public function valid() {
         if ($this->items !== null) {
-            return current($this->items) !== false;
+            return $this->items->valid();
         }
 
         return false;

--- a/src/spouts/facebook/page.php
+++ b/src/spouts/facebook/page.php
@@ -2,6 +2,7 @@
 
 namespace spouts\facebook;
 
+use ArrayIterator;
 use GuzzleHttp\Psr7\Uri;
 use helpers\WebClient;
 
@@ -74,7 +75,7 @@ class page extends \spouts\spout {
         $this->spoutTitle = $data['name'];
         $this->pagePicture = $data['picture']['data']['url'];
         $this->pageLink = $data['picture']['link'];
-        $this->items = $data['feed']['data'];
+        $this->items = new ArrayIterator($data['feed']['data']);
     }
 
     public function getHtmlUrl() {
@@ -82,8 +83,8 @@ class page extends \spouts\spout {
     }
 
     public function getId() {
-        if ($this->items !== null) {
-            $item = current($this->items);
+        if ($this->valid()) {
+            $item = $this->items->current();
 
             return $item['id'];
         }
@@ -92,8 +93,8 @@ class page extends \spouts\spout {
     }
 
     public function getTitle() {
-        if ($this->items !== null) {
-            $item = current($this->items);
+        if ($this->valid()) {
+            $item = $this->items->current();
 
             if (mb_strlen($item['message']) > 80) {
                 return mb_substr($item['message'], 0, 100) . '…';
@@ -106,8 +107,8 @@ class page extends \spouts\spout {
     }
 
     public function getContent() {
-        if ($this->items !== null) {
-            $item = current($this->items);
+        if ($this->valid()) {
+            $item = $this->items->current();
             $message = $item['message'];
 
             if (isset($item['attachments']) && count($item['attachments']['data']) > 0) {
@@ -137,8 +138,8 @@ class page extends \spouts\spout {
     }
 
     public function getLink() {
-        if ($this->items !== null) {
-            $item = current($this->items);
+        if ($this->valid()) {
+            $item = $this->items->current();
 
             return $item['permalink_url'];
         }
@@ -147,8 +148,8 @@ class page extends \spouts\spout {
     }
 
     public function getDate() {
-        if ($this->items !== null) {
-            $item = current($this->items);
+        if ($this->valid()) {
+            $item = $this->items->current();
 
             return $item['created_time'];
         }

--- a/src/spouts/github/commits.php
+++ b/src/spouts/github/commits.php
@@ -2,6 +2,7 @@
 
 namespace spouts\github;
 
+use ArrayIterator;
 use helpers\WebClient;
 
 /**
@@ -70,7 +71,8 @@ class commits extends \spouts\spout {
 
         $http = $this->webClient->getHttpClient();
         $response = $http->get($jsonUrl);
-        $this->items = json_decode((string) $response->getBody(), true);
+        $items = json_decode((string) $response->getBody(), true);
+        $this->items = new ArrayIterator($items);
 
         $this->spoutTitle = "Recent Commits to {$params['repo']}:{$params['branch']}";
     }
@@ -80,16 +82,16 @@ class commits extends \spouts\spout {
     }
 
     public function getId() {
-        if ($this->items !== null && $this->valid()) {
-            return @current($this->items)['sha'];
+        if ($this->valid()) {
+            return $this->items->current()['sha'];
         }
 
         return null;
     }
 
     public function getTitle() {
-        if ($this->items !== null && $this->valid()) {
-            $message = @current($this->items)['commit']['message'];
+        if ($this->valid()) {
+            $message = $this->items->current()['commit']['message'];
 
             return htmlspecialchars(self::cutTitle($message));
         }
@@ -98,8 +100,8 @@ class commits extends \spouts\spout {
     }
 
     public function getContent() {
-        if ($this->items !== null && $this->valid()) {
-            $message = @current($this->items)['commit']['message'];
+        if ($this->valid()) {
+            $message = $this->items->current()['commit']['message'];
 
             return nl2br(htmlspecialchars($message), false);
         }
@@ -112,16 +114,16 @@ class commits extends \spouts\spout {
     }
 
     public function getLink() {
-        if ($this->items !== null && $this->valid()) {
-            return @current($this->items)['html_url'];
+        if ($this->valid()) {
+            return $this->items->current()['html_url'];
         }
 
         return null;
     }
 
     public function getDate() {
-        if ($this->items !== null && $this->valid()) {
-            $date = date('Y-m-d H:i:s', strtotime(@current($this->items)['commit']['author']['date']));
+        if ($this->valid()) {
+            $date = date('Y-m-d H:i:s', strtotime($this->items->current()['commit']['author']['date']));
         }
         if (strlen($date) === 0) {
             $date = date('Y-m-d H:i:s');

--- a/src/spouts/reddit/reddit2.php
+++ b/src/spouts/reddit/reddit2.php
@@ -2,6 +2,7 @@
 
 namespace spouts\reddit;
 
+use ArrayIterator;
 use GuzzleHttp;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
@@ -90,13 +91,13 @@ class reddit2 extends \spouts\spout {
         }
 
         if (isset($json['data']) && isset($json['data']['children'])) {
-            $this->items = $json['data']['children'];
+            $this->items = new ArrayIterator($json['data']['children']);
         }
     }
 
     public function getId() {
-        if ($this->items !== null && $this->valid()) {
-            $id = @current($this->items)['data']['id'];
+        if ($this->valid()) {
+            $id = $this->items->current()['data']['id'];
             if (strlen($id) > 255) {
                 $id = md5($id);
             }
@@ -108,25 +109,25 @@ class reddit2 extends \spouts\spout {
     }
 
     public function getTitle() {
-        if ($this->items !== null && $this->valid()) {
-            return @current($this->items)['data']['title'];
+        if ($this->valid()) {
+            return $this->items->current()['data']['title'];
         }
 
         return null;
     }
 
     public function getHtmlUrl() {
-        if ($this->items !== null && $this->valid()) {
+        if ($this->valid()) {
             // Reddit escapes HTML, we can get away with just ampersands, since quotes and angle brackets are excluded from URLs.
-            return htmlspecialchars_decode(current($this->items)['data']['url'], ENT_NOQUOTES);
+            return htmlspecialchars_decode($this->items->current()['data']['url'], ENT_NOQUOTES);
         }
 
         return null;
     }
 
     public function getContent() {
-        if ($this->items !== null && $this->valid()) {
-            $data = @current($this->items)['data'];
+        if ($this->valid()) {
+            $data = $this->items->current()['data'];
             $text = $data['selftext_html'];
             if (!empty($text)) {
                 return htmlspecialchars_decode($text);
@@ -165,16 +166,16 @@ class reddit2 extends \spouts\spout {
     }
 
     public function getLink() {
-        if ($this->items !== null && $this->valid()) {
-            return 'https://www.reddit.com' . @current($this->items)['data']['permalink'];
+        if ($this->valid()) {
+            return 'https://www.reddit.com' . $this->items->current()['data']['permalink'];
         }
 
         return null;
     }
 
     public function getThumbnail() {
-        if ($this->items !== null && $this->valid()) {
-            $thumbnail = @current($this->items)['data']['thumbnail'];
+        if ($this->valid()) {
+            $thumbnail = $this->items->current()['data']['thumbnail'];
 
             if (!in_array($thumbnail, ['default', 'self'], true)) {
                 return $thumbnail;
@@ -185,8 +186,8 @@ class reddit2 extends \spouts\spout {
     }
 
     public function getdate() {
-        if ($this->items !== null && $this->valid()) {
-            $date = date('Y-m-d H:i:s', @current($this->items)['data']['created_utc']);
+        if ($this->valid()) {
+            $date = date('Y-m-d H:i:s', $this->items->current()['data']['created_utc']);
         }
 
         return $date;

--- a/src/spouts/rss/enclosures.php
+++ b/src/spouts/rss/enclosures.php
@@ -17,9 +17,9 @@ class enclosures extends feed {
     public $description = 'Get posts from RSS feed, including media enclosures.';
 
     public function getContent() {
-        if ($this->items !== null && $this->valid()) {
+        if ($this->valid()) {
             $content = parent::getContent();
-            foreach (@current($this->items)->get_enclosures() as $enclosure) {
+            foreach ($this->items->current()->get_enclosures() as $enclosure) {
                 if ($enclosure->get_medium() === 'image') {
                     $title = htmlspecialchars(strip_tags($enclosure->get_title()));
                     $content .= '<img src="' . $enclosure->get_link() . '" alt="' . $title . '" title="' . $title . '" />';

--- a/src/spouts/rss/feed.php
+++ b/src/spouts/rss/feed.php
@@ -2,6 +2,7 @@
 
 namespace spouts\rss;
 
+use ArrayIterator;
 use helpers\FeedReader;
 use helpers\Image;
 use Monolog\Logger;
@@ -57,7 +58,7 @@ class feed extends \spouts\spout {
 
     public function load(array $params) {
         $feedData = $this->feed->load(htmlspecialchars_decode($params['url']));
-        $this->items = $feedData['items'];
+        $this->items = new ArrayIterator($feedData['items']);
         $this->htmlUrl = $feedData['htmlUrl'];
         $this->spoutTitle = $feedData['spoutTitle'];
     }
@@ -71,8 +72,8 @@ class feed extends \spouts\spout {
     }
 
     public function getId() {
-        if ($this->items !== null && $this->valid()) {
-            $id = @current($this->items)->get_id();
+        if ($this->valid()) {
+            $id = $this->items->current()->get_id();
             if (strlen($id) > 255) {
                 $id = md5($id);
             }
@@ -84,16 +85,16 @@ class feed extends \spouts\spout {
     }
 
     public function getTitle() {
-        if ($this->items !== null && $this->valid()) {
-            return htmlspecialchars_decode(@current($this->items)->get_title());
+        if ($this->valid()) {
+            return htmlspecialchars_decode($this->items->current()->get_title());
         }
 
         return null;
     }
 
     public function getContent() {
-        if ($this->items !== null && $this->valid()) {
-            return @current($this->items)->get_content();
+        if ($this->valid()) {
+            return $this->items->current()->get_content();
         }
 
         return null;
@@ -142,8 +143,8 @@ class feed extends \spouts\spout {
     }
 
     public function getLink() {
-        if ($this->items !== null && $this->valid()) {
-            $link = @current($this->items)->get_link();
+        if ($this->valid()) {
+            $link = $this->items->current()->get_link();
 
             return htmlspecialchars_decode($link, ENT_COMPAT); // SimplePie sanitizes URLs
         }
@@ -152,8 +153,8 @@ class feed extends \spouts\spout {
     }
 
     public function getDate() {
-        if ($this->items !== null && $this->valid()) {
-            $date = @current($this->items)->get_date('Y-m-d H:i:s');
+        if ($this->valid()) {
+            $date = $this->items->current()->get_date('Y-m-d H:i:s');
         }
         if (strlen($date) === 0) {
             $date = date('Y-m-d H:i:s');
@@ -163,8 +164,8 @@ class feed extends \spouts\spout {
     }
 
     public function getAuthor() {
-        if ($this->items !== null && $this->valid()) {
-            $author = @current($this->items)->get_author();
+        if ($this->valid()) {
+            $author = $this->items->current()->get_author();
             if (isset($author)) {
                 $name = $author->get_name();
                 if (isset($name)) {

--- a/src/spouts/rss/images.php
+++ b/src/spouts/rss/images.php
@@ -17,11 +17,11 @@ class images extends feed {
     public $description = 'Fetch images from given rss feed.';
 
     public function getThumbnail() {
-        if ($this->items === null || $this->valid() === false) {
+        if (!$this->valid()) {
             return '';
         }
 
-        $item = current($this->items);
+        $item = $this->items->current();
 
         // search enclosures (media tags)
         if (count(@$item->get_enclosures()) > 0) {

--- a/src/spouts/twitter/usertimeline.php
+++ b/src/spouts/twitter/usertimeline.php
@@ -2,6 +2,7 @@
 
 namespace spouts\twitter;
 
+use ArrayIterator;
 use GuzzleHttp;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Subscriber\Oauth\Oauth1;
@@ -117,7 +118,7 @@ class usertimeline extends \spouts\spout {
      * @throws \Exception when API request fails
      * @throws GuzzleHttp\Exception\RequestException when HTTP request fails for API-unrelated reasons
      *
-     * @return stdClass[]
+     * @return ArrayIterator<stdClass>
      */
     protected function fetchTwitterTimeline($endpoint, array $params = []) {
         if (!isset($this->client)) {
@@ -143,7 +144,7 @@ class usertimeline extends \spouts\spout {
                 throw new \Exception('Invalid twitter response');
             }
 
-            return $timeline;
+            return new ArrayIterator($timeline);
         } catch (BadResponseException $e) {
             if ($e->hasResponse()) {
                 $body = json_decode((string) $e->getResponse()->getBody());
@@ -187,7 +188,7 @@ class usertimeline extends \spouts\spout {
 
     public function getId() {
         if ($this->items !== null) {
-            return @current($this->items)->id_str;
+            return $this->items->current()->id_str;
         }
 
         return null;
@@ -195,7 +196,7 @@ class usertimeline extends \spouts\spout {
 
     public function getTitle() {
         if ($this->items !== null) {
-            $item = @current($this->items);
+            $item = $this->items->current();
             $rt = '';
             if (isset($item->retweeted_status)) {
                 $rt = ' (RT ' . $item->user->name . ')';
@@ -242,7 +243,7 @@ class usertimeline extends \spouts\spout {
 
     public function getIcon() {
         if ($this->items !== null) {
-            $item = @current($this->items);
+            $item = $this->items->current();
             if (isset($item->retweeted_status)) {
                 $item = $item->retweeted_status;
             }
@@ -255,7 +256,7 @@ class usertimeline extends \spouts\spout {
 
     public function getLink() {
         if ($this->items !== null) {
-            $item = @current($this->items);
+            $item = $this->items->current();
 
             return 'https://twitter.com/' . $item->user->screen_name . '/status/' . $item->id_str;
         }
@@ -279,7 +280,7 @@ class usertimeline extends \spouts\spout {
 
     public function getDate() {
         if ($this->items !== null) {
-            $date = date('Y-m-d H:i:s', strtotime(@current($this->items)->created_at));
+            $date = date('Y-m-d H:i:s', strtotime($this->items->current()->created_at));
         }
         if (strlen($date) === 0) {
             $date = date('Y-m-d H:i:s');

--- a/src/spouts/youtube/youtube.php
+++ b/src/spouts/youtube/youtube.php
@@ -56,11 +56,11 @@ class youtube extends \spouts\rss\feed {
     }
 
     public function getThumbnail() {
-        if ($this->items === null || !$this->valid()) {
-            return null;
+        if (!$this->valid()) {
+            return '';
         }
 
-        $item = current($this->items);
+        $item = $this->items->current();
 
         // search enclosures (media tags)
         if (count(@$item->get_enclosures()) > 0) {


### PR DESCRIPTION
This will make it easier to implement spouts that do not fetch all items at once.

Also fix return values of the ItemsIterator:

 - Iterator::next() should not return anything.
 - null should be returned when Iterator is invalid.
