### PR TITLE
Remove anonymizer support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -116,6 +116,7 @@
 - Search button is now always on the screen, avoiding the need to scroll to top to be able to use it. ([#1231](https://github.com/fossar/selfoss/issues/1231))
 - Button for opening articles, tags, sources and filters in the sidebar, as well as the source and tag links in articles are now real links, allowing to open them in a new tab by middle-clicking them. ([#1216](https://github.com/fossar/selfoss/issues/1216), [#695](https://github.com/fossar/selfoss/issues/695))
 - Configuration is no longer managed by F3 framework. ([#1261](https://github.com/fossar/selfoss/pull/1261))
+- Removed `anonymizer` configuration option. ([#1358](https://github.com/fossar/selfoss/pull/1358))
 
 
 ## 2.18 – 2018-03-05

--- a/assets/js/selfoss-base.js
+++ b/assets/js/selfoss-base.js
@@ -382,24 +382,6 @@ var selfoss = {
 
 
     /**
-     * anonymize links
-     *
-     * @return void
-     * @param parent element
-     */
-    anonymize: function(parent) {
-        var anonymizer = selfoss.config.anonymizer;
-        if (anonymizer !== null) {
-            parent.querySelectorAll('a').forEach((link) => {
-                if (typeof link.getAttribute('href') !== 'undefined' && !link.getAttribute('href').startsWith(anonymizer)) {
-                    link.setAttribute('href', anonymizer + link.getAttribute('href'));
-                }
-            });
-        }
-    },
-
-
-    /**
      * Setup fancyBox image viewer
      * @param content element
      * @param int

--- a/assets/js/templates/Item.jsx
+++ b/assets/js/templates/Item.jsx
@@ -11,10 +11,6 @@ import { forceReload, makeEntriesLink, makeEntriesLinkLocation } from '../helper
 import * as icons from '../icons';
 import { LocalizationContext } from '../helpers/i18n';
 
-function anonymize(url) {
-    return (selfoss.config.anonymizer ?? '') + url;
-}
-
 function stopPropagation(event) {
     event.stopPropagation();
 }
@@ -294,11 +290,6 @@ export default function Item({ currentTime, item, selected, expanded, setNavExpa
                     });
                 }
             }
-
-            if (firstExpansion) {
-                // anonymize
-                selfoss.anonymize(contentBlock.current);
-            }
         } else {
             // No longer expanded.
 
@@ -392,7 +383,7 @@ export default function Item({ currentTime, item, selected, expanded, setNavExpa
 
             {/* icon */}
             <a
-                href={anonymize(item.link)}
+                href={item.link}
                 className="entry-icon"
                 tabIndex="-1"
                 rel="noreferrer"
@@ -451,7 +442,7 @@ export default function Item({ currentTime, item, selected, expanded, setNavExpa
 
             {/* datetime */}
             <a
-                href={anonymize(item.link)}
+                href={item.link}
                 className={classNames({'entry-datetime': true, timestamped: relDate === null})}
                 target="_blank"
                 rel="noreferrer"
@@ -471,7 +462,7 @@ export default function Item({ currentTime, item, selected, expanded, setNavExpa
             {/* thumbnail */}
             {item.thumbnail && item.thumbnail.trim().length > 0 ?
                 <div className={classNames({'entry-thumbnail': true, 'entry-thumbnail-always-visible': selfoss.config.showThumbnails})}>
-                    <a href={anonymize(item.link)} target="_blank" rel="noreferrer">
+                    <a href={item.link} target="_blank" rel="noreferrer">
                         <img src={`thumbnails/${item.thumbnail}`} alt={item.strippedTitle} />
                     </a>
                 </div>
@@ -485,7 +476,7 @@ export default function Item({ currentTime, item, selected, expanded, setNavExpa
                     <ul aria-label={_('article_actions')}>
                         <li>
                             <a
-                                href={anonymize(item.link)}
+                                href={item.link}
                                 className="entry-newwindow"
                                 target="_blank"
                                 rel="noreferrer"
@@ -540,7 +531,7 @@ export default function Item({ currentTime, item, selected, expanded, setNavExpa
                 }
                 <li>
                     <a
-                        href={anonymize(item.link)}
+                        href={item.link}
                         className="entry-newwindow"
                         target="_blank"
                         rel="noreferrer"

--- a/docs/content/docs/administration/options.md
+++ b/docs/content/docs/administration/options.md
@@ -200,12 +200,6 @@ set `0` or leave empty for auto detection (browser language) or use one of the f
 * Ukrainian: `uk`
 </div>
 
-### `anonymizer`
-<div class="config-option">
-
-Set here your anonymizer service url. e.g.: `anonymizer=https://anonym.to/?`
-</div>
-
 ### `allow_public_update_access`
 <div class="config-option">
 

--- a/src/controllers/About.php
+++ b/src/controllers/About.php
@@ -42,7 +42,6 @@ class About {
             'apiversion' => SELFOSS_API_VERSION,
             'configuration' => [
                 'homepage' => $this->configuration->homepage ? $this->configuration->homepage : 'newest', // string
-                'anonymizer' => $this->configuration->anonymizer, // ?string
                 'share' => $this->configuration->share, // string
                 'wallabag' => $wallabag, // ?array
                 'wordpress' => $this->configuration->wordpress, // ?string

--- a/src/helpers/Configuration.php
+++ b/src/helpers/Configuration.php
@@ -122,9 +122,6 @@ class Configuration {
     /** @var bool */
     public $openInBackgroundTab = false;
 
-    /** @var ?string */
-    public $anonymizer = null;
-
     /** @var string */
     public $share = 'atfpde';
 


### PR DESCRIPTION
Initially implemented in https://github.com/fossar/selfoss/issues/104, these were mostly meant to strip the `Referer` header. But we have long been specifying `rel="noreferer"` on links, which achieved the same effect without going through a questionable third-party website that usually messed up the viewed web page.

For better privacy, web browser extensions like NoScript or uBlock Origin and Tor or a VPN provider are probably much better anyway.

Closes: https://github.com/fossar/selfoss/issues/612
