### PR TITLE
Use HtmlString to distinguish between HTML and plain text strings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 ### Customization changes
 - Custom spout parameter declarations should now use constants from `Parameter` interface. ([#1409](https://github.com/fossar/selfoss/pull/1409))
+- Custom spouts are expected to pass `HtmlString` object to items’ title and content. ([#1368](https://github.com/fossar/selfoss/pull/1368))
 
 ### Other changes
 - `tidy` PHP extension is now required if you want to use “Content extractor” spout. ([#1392](https://github.com/fossar/selfoss/pull/1392))

--- a/docs/api-description.json
+++ b/docs/api-description.json
@@ -951,12 +951,12 @@
             "example": "2013-04-07T13:43:00+01:00"
           },
           "title": {
-            "description": "the title of the article",
+            "description": "The title of the article, can contain HTML tags",
             "type": "string",
             "example": "FTTH: Google Fiber für eine neue Großstadt"
           },
           "content": {
-            "description": "the full content of the article",
+            "description": "The full content of the article as a HTML fragment.",
             "type": "string",
             "example": "\n<p>Das 1-GBit/s-Angebot Google Fiber kommt nach Austin, die Hauptstadt des US-Bundesstaates Texas..."
           },

--- a/src/daos/mysql/Items.php
+++ b/src/daos/mysql/Items.php
@@ -9,6 +9,7 @@ use daos\ItemOptions;
 use DateTime;
 use DateTimeImmutable;
 use helpers\Configuration;
+use helpers\HtmlString;
 use Monolog\Logger;
 
 /**
@@ -103,6 +104,8 @@ class Items implements \daos\ItemsInterface {
 
     /**
      * add new item
+     *
+     * @param array{datetime: \DateTimeInterface, title: HtmlString, content: HtmlString, thumbnail: ?string, icon: ?string, source: int, uid: string, link: string, author: ?string} $values
      */
     public function add(array $values): void {
         $this->database->exec('INSERT INTO ' . $this->configuration->dbPrefix . 'items (
@@ -131,9 +134,9 @@ class Items implements \daos\ItemsInterface {
                     :author
                   )',
                  [
-                    ':datetime' => $values['datetime'],
-                    ':title' => $values['title'],
-                    ':content' => $values['content'],
+                    ':datetime' => $values['datetime']->format('Y-m-d H:i:s'),
+                    ':title' => $values['title']->getRaw(),
+                    ':content' => $values['content']->getRaw(),
                     ':thumbnail' => $values['thumbnail'],
                     ':icon' => $values['icon'],
                     ':unread' => 1,

--- a/src/helpers/HtmlString.php
+++ b/src/helpers/HtmlString.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace helpers;
+
+/**
+ * A string wrapper representing a HTML fragment.
+ */
+class HtmlString {
+    /** @var string */
+    private $content;
+
+    private function __construct(string $content) {
+        $this->content = $content;
+    }
+
+    /**
+     * Creates a new HtmlString from a string containing a HTML fragment.
+     */
+    public static function fromRaw(string $content): self {
+        return new self($content);
+    }
+
+    /**
+     * Creates a new HtmlString from a plain text string.
+     */
+    public static function fromPlainText(string $content): self {
+        return new self(htmlspecialchars($content));
+    }
+
+    /**
+     * Returns a HTML fragment represented by the object.
+     */
+    public function getRaw(): string {
+        return $this->content;
+    }
+
+    /**
+     * Returns a plain text without any HTML tags.
+     */
+    public function getPlainText(): string {
+        return htmlspecialchars_decode(strip_tags($this->content));
+    }
+}

--- a/src/helpers/ImageUtils.php
+++ b/src/helpers/ImageUtils.php
@@ -117,7 +117,7 @@ class ImageUtils {
         if (stripos($html, '<img') !== false) {
             $imgsrc_regex = '#<\s*img [^\>]*src\s*=\s*(["\'])(.*?)\1#im';
             if (preg_match($imgsrc_regex, $html, $matches)) {
-                return $matches[2];
+                return htmlspecialchars_decode($matches[2]);
             } else {
                 return null;
             }

--- a/src/spouts/Item.php
+++ b/src/spouts/Item.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace spouts;
 
 use DateTimeInterface;
+use helpers\HtmlString;
 
 /**
  * Value object representing a source item (e.g. an article).
@@ -15,10 +16,10 @@ class Item {
     /** @var string an unique id for this item */
     private $id;
 
-    /** @var string title */
+    /** @var HtmlString title */
     private $title;
 
-    /** @var string content */
+    /** @var HtmlString content */
     private $content;
 
     /** @var ?string thumbnail */
@@ -44,8 +45,8 @@ class Item {
      */
     public function __construct(
         string $id,
-        string $title,
-        string $content,
+        HtmlString $title,
+        HtmlString $content,
         ?string $thumbnail,
         ?string $icon,
         string $link,
@@ -89,14 +90,14 @@ class Item {
      * If the spout allows HTML in the title, HTML special chars are expected to be decoded by the spout
      * (for instance when the spout feed is XML).
      */
-    public function getTitle(): string {
+    public function getTitle(): HtmlString {
         return $this->title;
     }
 
     /**
      * @return static
      */
-    public function withTitle(string $title): self {
+    public function withTitle(HtmlString $title): self {
         $modified = clone $this;
         $modified->title = $title;
 
@@ -109,14 +110,14 @@ class Item {
      * HTML special chars are expected to be decoded by the spout
      * (for instance when the spout feed is XML).
      */
-    public function getContent(): string {
+    public function getContent(): HtmlString {
         return $this->content;
     }
 
     /**
      * @return static
      */
-    public function withContent(string $content): self {
+    public function withContent(HtmlString $content): self {
         $modified = clone $this;
         $modified->content = $content;
 

--- a/src/spouts/facebook/page.php
+++ b/src/spouts/facebook/page.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace spouts\facebook;
 
 use GuzzleHttp\Psr7\Uri;
+use helpers\HtmlString;
 use helpers\WebClient;
 use spouts\Item;
 use spouts\Parameter;
@@ -107,7 +108,7 @@ class page extends \spouts\spout {
     public function getItems(): iterable {
         foreach ($this->items as $item) {
             $id = $item['id'];
-            $title = mb_strlen($item['message']) > 80 ? mb_substr($item['message'], 0, 100) . '…' : $item['message'];
+            $title = HtmlString::fromPlainText((mb_strlen($item['message']) > 80 ? mb_substr($item['message'], 0, 100) . '…' : $item['message']));
             $content = $this->getPostContent($item);
             $thumbnail = null;
             $icon = null;
@@ -131,18 +132,18 @@ class page extends \spouts\spout {
         }
     }
 
-    private function getPostContent(array $item): string {
-        $message = $item['message'];
+    private function getPostContent(array $item): HtmlString {
+        $message = htmlspecialchars($item['message']);
 
         if (isset($item['attachments']) && count($item['attachments']['data']) > 0) {
             foreach ($item['attachments']['data'] as $media) {
                 if ($media['type'] === 'photo') {
                     $message .= '<figure>' . PHP_EOL;
-                    $message .= '<a href="' . $media['target']['url'] . '"><img src="' . $media['media']['image']['src'] . '" alt=""></a>' . PHP_EOL;
+                    $message .= '<a href="' . htmlspecialchars($media['target']['url'], ENT_QUOTES) . '"><img src="' . htmlspecialchars($media['media']['image']['src'], ENT_QUOTES) . '" alt=""></a>' . PHP_EOL;
 
                     // Some photos will have the same description, no need to display it twice
                     if ($media['description'] !== $item['message']) {
-                        $message .= '<figcaption>' . $media['description'] . '</figcaption>' . PHP_EOL;
+                        $message .= '<figcaption>' . htmlspecialchars($media['description']) . '</figcaption>' . PHP_EOL;
                     }
 
                     $message .= '</figure>' . PHP_EOL;
@@ -150,6 +151,6 @@ class page extends \spouts\spout {
             }
         }
 
-        return $message;
+        return HtmlString::fromRaw($message);
     }
 }

--- a/src/spouts/github/commits.php
+++ b/src/spouts/github/commits.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace spouts\github;
 
+use helpers\HtmlString;
 use helpers\WebClient;
 use spouts\Item;
 use spouts\Parameter;
@@ -107,8 +108,8 @@ class commits extends \spouts\spout {
             $message = $item['commit']['message'];
 
             $id = $item['sha'];
-            $title = htmlspecialchars(self::cutTitle($message));
-            $content = nl2br(htmlspecialchars($message), false);
+            $title = HtmlString::fromPlainText(self::cutTitle($message));
+            $content = HtmlString::fromRaw(nl2br(htmlspecialchars($message), false));
             $thumbnail = null;
             $icon = null;
             $link = $item['html_url'];

--- a/src/spouts/rss/enclosures.php
+++ b/src/spouts/rss/enclosures.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace spouts\rss;
 
+use helpers\HtmlString;
 use SimplePie;
 use spouts\Item;
 
@@ -31,21 +32,22 @@ class enclosures extends feed {
         }
     }
 
-    private function getContentWithEnclosures(string $content, SimplePie\Item $item): string {
+    private function getContentWithEnclosures(HtmlString $content, SimplePie\Item $item): HtmlString {
         $enclosures = $item->get_enclosures();
         if ($enclosures === null) {
             return $content;
         }
 
-        $newContent = $content;
+        $newContent = $content->getRaw();
 
         foreach ($enclosures as $enclosure) {
             if ($enclosure->get_medium() === 'image') {
-                $title = htmlspecialchars(strip_tags((string) $enclosure->get_title()));
-                $newContent .= '<img src="' . $enclosure->get_link() . '" alt="' . $title . '" title="' . $title . '" />';
+                $title = htmlspecialchars(strip_tags((string) $enclosure->get_title()), ENT_QUOTES);
+                $url = htmlspecialchars_decode($enclosure->get_link(), ENT_COMPAT); // SimplePie sanitizes URLs
+                $newContent .= '<img src="' . htmlspecialchars($url, ENT_QUOTES) . '" alt="' . $title . '" title="' . $title . '" />';
             }
         }
 
-        return $newContent;
+        return HtmlString::fromRaw($newContent);
     }
 }

--- a/src/spouts/rss/feed.php
+++ b/src/spouts/rss/feed.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace spouts\rss;
 
 use helpers\FeedReader;
+use helpers\HtmlString;
 use helpers\Image;
 use Monolog\Logger;
 use SimplePie;
@@ -94,8 +95,10 @@ class feed extends \spouts\spout {
             if (strlen($id) > 255) {
                 $id = md5($id);
             }
-            $title = htmlspecialchars_decode((string) $item->get_title());
-            $content = (string) $item->get_content();
+            $title = (string) $item->get_title();
+            // Atom feeds can contain HTML in titles, strip tags and convert to text.
+            $title = HtmlString::fromPlainText(htmlspecialchars_decode(strip_tags($title)));
+            $content = HtmlString::fromRaw((string) $item->get_content());
             $thumbnail = null;
             $icon = null;
             $link = htmlspecialchars_decode((string) $item->get_link(), ENT_COMPAT); // SimplePie sanitizes URLs

--- a/src/spouts/rss/fulltextrss.php
+++ b/src/spouts/rss/fulltextrss.php
@@ -7,6 +7,7 @@ namespace spouts\rss;
 use Graby\Graby;
 use helpers\Configuration;
 use helpers\FeedReader;
+use helpers\HtmlString;
 use helpers\Image;
 use helpers\WebClient;
 use Http\Adapter\Guzzle7\Client as GuzzleAdapter;
@@ -77,7 +78,7 @@ class fulltextrss extends feed {
     /**
      * @param Item<SimplePie\Item> $item
      */
-    public function getFullContent(string $url, Item $item): string {
+    public function getFullContent(string $url, Item $item): HtmlString {
         if ($this->graby === null) {
             $this->graby = new Graby([
                 'extractor' => [
@@ -97,10 +98,10 @@ class fulltextrss extends feed {
         if ($response['status'] !== 200) {
             $this->logger->error('Failed loading page');
 
-            return '<p><strong>Failed to get web page</strong></p>' . $item->getContent();
+            return HtmlString::fromRaw('<p><strong>Failed to get web page</strong></p>' . $item->getContent()->getRaw());
         }
 
-        $content = $response['html'];
+        $content = HtmlString::fromRaw($response['html']);
 
         return $content;
     }

--- a/tests/Spouts/YouTubeTest.php
+++ b/tests/Spouts/YouTubeTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
+use helpers\HtmlString;
 use helpers\WebClient;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
@@ -18,7 +19,7 @@ final class YouTubeTest extends TestCase {
     /**
      * @dataProvider dataProvider
      */
-    public function testBasic(string $url, string $feedTitle, string $firstItemTitle): void {
+    public function testBasic(string $url, string $feedTitle, HtmlString $firstItemTitle): void {
         $cachedFeedPath = __DIR__ . '/resources/YouTube/' . str_replace([':', '/', '?', '='], '_', $url) . '.xml';
 
         $mock = new MockHandler([
@@ -61,34 +62,34 @@ final class YouTubeTest extends TestCase {
     }
 
     /**
-     * @return array<array{url: string, feedTitle: string, firstItemTitle: string}>
+     * @return array<array{url: string, feedTitle: string, firstItemTitle: HtmlString}>
      */
     public function dataProvider(): array {
         return [
             [
                 'url' => 'https://www.youtube.com/user/ZoggFromBetelgeuse',
                 'feedTitle' => 'Zogg from Betelgeuse',
-                'firstItemTitle' => 'Earthlings 101 - Channel Ad',
+                'firstItemTitle' => HtmlString::fromPlainText('Earthlings 101 - Channel Ad'),
             ],
             [
                 'url' => 'https://www.youtube.com/channel/UCKY00CSQo1MoC27bdGd-w_g',
                 'feedTitle' => 'Zogg from Betelgeuse',
-                'firstItemTitle' => 'Earthlings 101 - Channel Ad',
+                'firstItemTitle' => HtmlString::fromPlainText('Earthlings 101 - Channel Ad'),
             ],
             [
                 'url' => 'https://www.youtube.com/ZoggFromBetelgeuse',
                 'feedTitle' => 'Zogg from Betelgeuse',
-                'firstItemTitle' => 'Earthlings 101 - Channel Ad',
+                'firstItemTitle' => HtmlString::fromPlainText('Earthlings 101 - Channel Ad'),
             ],
             [
                 'url' => 'ZoggFromBetelgeuse',
                 'feedTitle' => 'Zogg from Betelgeuse',
-                'firstItemTitle' => 'Earthlings 101 - Channel Ad',
+                'firstItemTitle' => HtmlString::fromPlainText('Earthlings 101 - Channel Ad'),
             ],
             [
                 'url' => 'https://www.youtube.com/playlist?list=PLKhDkilF5o6_pFucn5JHd6xy7muHLK6pS',
                 'feedTitle' => 'BeeKeeping',
-                'firstItemTitle' => 'Year of BeeKeeping Episode 15, Finding Queen',
+                'firstItemTitle' => HtmlString::fromPlainText('Year of BeeKeeping Episode 15, Finding Queen'),
             ],
         ];
     }


### PR DESCRIPTION
The database also contains other escaped values:

- https://github.com/fossar/selfoss/blob/ac61872689c24352ed912a231974376b15d41657/src/helpers/ViewHelper.php#L144
- https://github.com/fossar/selfoss/blob/0920dcbd1fe18a5369f7fe49dea8e7f0e2bfbeeb/src/controllers/Sources/Write.php#L78
- https://github.com/fossar/selfoss/blob/0920dcbd1fe18a5369f7fe49dea8e7f0e2bfbeeb/src/controllers/Sources/Write.php#L82

Similarly the view layer:

- https://github.com/fossar/selfoss/blob/ac61872689c24352ed912a231974376b15d41657/src/helpers/ViewHelper.php#L144

So I decided to first systematize the data model by using explicit object for HTML string.

Now we just need to remove the escaping everywhere else (will be a BC break).