### PR TITLE
Update to react-router 7

### DIFF
--- a/client/js/helpers/hooks.js
+++ b/client/js/helpers/hooks.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useMediaMatch } from 'rooks';
 
 /**

--- a/client/js/helpers/uri.js
+++ b/client/js/helpers/uri.js
@@ -1,4 +1,4 @@
-import { useLocation, useMatch } from 'react-router-dom';
+import { useLocation, useMatch } from 'react-router';
 import { FilterType } from '../Filter';
 
 /**

--- a/client/js/selfoss-base.js
+++ b/client/js/selfoss-base.js
@@ -281,7 +281,7 @@ const selfoss = {
             await logout();
 
             if (!selfoss.config.publicMode) {
-                selfoss.history.push('/sign/in');
+                selfoss.navigate('/sign/in');
             }
         } catch (error) {
             selfoss.app.showError(

--- a/client/js/templates/App.jsx
+++ b/client/js/templates/App.jsx
@@ -9,7 +9,7 @@ import {
     Navigate,
     useNavigate,
     useLocation,
-} from 'react-router-dom';
+} from 'react-router';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Collapse } from '@kunukn/react-collapse';
 import classNames from 'classnames';
@@ -852,15 +852,7 @@ App.propTypes = {
  */
 export function createApp({ basePath, appRef, configuration }) {
     return (
-        <Router
-            basename={basePath}
-            future={{
-                // eslint-disable-next-line camelcase
-                v7_startTransition: true,
-                // eslint-disable-next-line camelcase
-                v7_relativeSplatPath: true,
-            }}
-        >
+        <Router basename={basePath}>
             <App ref={appRef} configuration={configuration} />
         </Router>
     );

--- a/client/js/templates/App.jsx
+++ b/client/js/templates/App.jsx
@@ -334,9 +334,8 @@ function PureApp({
                                     />
                                     <Route
                                         path={ENTRIES_ROUTE_PATTERN}
-                                        render={(routeProps) => (
+                                        render={() => (
                                             <EntriesPage
-                                                {...routeProps}
                                                 ref={entriesRef}
                                                 setNavExpanded={setNavExpanded}
                                                 configuration={configuration}

--- a/client/js/templates/App.jsx
+++ b/client/js/templates/App.jsx
@@ -213,7 +213,7 @@ function PureApp({
 
                 <Route path="/opml">
                     <CheckAuthorization
-                        isAllowed={selfoss.isAllowedToWrite()}
+                        isAllowed={isAllowedToWrite}
                         returnLocation="/opml"
                         _={_}
                     >

--- a/client/js/templates/App.jsx
+++ b/client/js/templates/App.jsx
@@ -192,153 +192,179 @@ function PureApp({
             <Message message={globalMessage} />
 
             <Switch>
-                <Route path="/sign/in">
-                    {/* menu open for smartphone */}
-                    <div id="loginform" role="main">
-                        <LoginForm {...{ offlineEnabled }} />
-                    </div>
-                </Route>
-
-                <Route path="/password">
-                    <CheckAuthorization
-                        isAllowed={isAllowedToWrite}
-                        returnLocation="/password"
-                        _={_}
-                    >
-                        <div id="hashpasswordbody" role="main">
-                            <HashPassword setTitle={setTitle} />
+                <Route
+                    path="/sign/in"
+                    render={() => (
+                        /* menu open for smartphone */
+                        <div id="loginform" role="main">
+                            <LoginForm {...{ offlineEnabled }} />
                         </div>
-                    </CheckAuthorization>
-                </Route>
+                    )}
+                />
 
-                <Route path="/opml">
-                    <CheckAuthorization
-                        isAllowed={isAllowedToWrite}
-                        returnLocation="/opml"
-                        _={_}
-                    >
-                        <main id="opmlbody">
-                            <OpmlImport setTitle={setTitle} />
-                        </main>
-                    </CheckAuthorization>
-                </Route>
+                <Route
+                    path="/password"
+                    render={() => (
+                        <CheckAuthorization
+                            isAllowed={isAllowedToWrite}
+                            returnLocation="/password"
+                            _={_}
+                        >
+                            <div id="hashpasswordbody" role="main">
+                                <HashPassword setTitle={setTitle} />
+                            </div>
+                        </CheckAuthorization>
+                    )}
+                />
 
-                <Route path="/">
-                    <CheckAuthorization isAllowed={isAllowedToRead} _={_}>
-                        <div id="nav-mobile" role="navigation">
-                            <div id="nav-mobile-logo">
-                                <div
-                                    id="nav-mobile-count"
-                                    className={classNames({
-                                        'unread-count': true,
-                                        offline: offlineState,
-                                        online: !offlineState,
-                                        unread: unreadItemsCount > 0,
-                                    })}
-                                >
-                                    <span
+                <Route
+                    path="/opml"
+                    render={() => (
+                        <CheckAuthorization
+                            isAllowed={isAllowedToWrite}
+                            returnLocation="/opml"
+                            _={_}
+                        >
+                            <main id="opmlbody">
+                                <OpmlImport setTitle={setTitle} />
+                            </main>
+                        </CheckAuthorization>
+                    )}
+                />
+
+                <Route
+                    path="/"
+                    render={() => (
+                        <CheckAuthorization isAllowed={isAllowedToRead} _={_}>
+                            <div id="nav-mobile" role="navigation">
+                                <div id="nav-mobile-logo">
+                                    <div
+                                        id="nav-mobile-count"
                                         className={classNames({
-                                            'offline-count': true,
+                                            'unread-count': true,
                                             offline: offlineState,
                                             online: !offlineState,
-                                            diff:
-                                                unreadItemsCount !==
-                                                    unreadItemsOfflineCount &&
-                                                unreadItemsOfflineCount,
+                                            unread: unreadItemsCount > 0,
                                         })}
                                     >
-                                        {unreadItemsOfflineCount > 0
-                                            ? unreadItemsOfflineCount
-                                            : ''}
-                                    </span>
-                                    <span className="count">
-                                        {unreadItemsCount}
-                                    </span>
+                                        <span
+                                            className={classNames({
+                                                'offline-count': true,
+                                                offline: offlineState,
+                                                online: !offlineState,
+                                                diff:
+                                                    unreadItemsCount !==
+                                                        unreadItemsOfflineCount &&
+                                                    unreadItemsOfflineCount,
+                                            })}
+                                        >
+                                            {unreadItemsOfflineCount > 0
+                                                ? unreadItemsOfflineCount
+                                                : ''}
+                                        </span>
+                                        <span className="count">
+                                            {unreadItemsCount}
+                                        </span>
+                                    </div>
                                 </div>
-                            </div>
-                            <button
-                                id="nav-mobile-settings"
-                                accessKey="t"
-                                aria-label={_('settingsbutton')}
-                                onClick={menuButtonOnClick}
-                            >
-                                <FontAwesomeIcon icon={icons.menu} size="2x" />
-                            </button>
-                        </div>
-
-                        {/* navigation */}
-                        <Collapse
-                            isOpen={!smartphone || navExpanded}
-                            className="collapse-css-transition"
-                        >
-                            <div id="nav" role="navigation">
-                                <Navigation
-                                    entriesPage={entriesPage}
-                                    setNavExpanded={setNavExpanded}
-                                    navSourcesExpanded={navSourcesExpanded}
-                                    setNavSourcesExpanded={
-                                        setNavSourcesExpanded
-                                    }
-                                    offlineState={offlineState}
-                                    allItemsCount={allItemsCount}
-                                    allItemsOfflineCount={allItemsOfflineCount}
-                                    unreadItemsCount={unreadItemsCount}
-                                    unreadItemsOfflineCount={
-                                        unreadItemsOfflineCount
-                                    }
-                                    starredItemsCount={starredItemsCount}
-                                    starredItemsOfflineCount={
-                                        starredItemsOfflineCount
-                                    }
-                                    sourcesState={sourcesState}
-                                    setSourcesState={setSourcesState}
-                                    sources={sources}
-                                    setSources={setSources}
-                                    tags={tags}
-                                    reloadAll={reloadAll}
-                                />
-                            </div>
-                        </Collapse>
-
-                        <ul id="search-list">
-                            <SearchList />
-                        </ul>
-
-                        {/* content */}
-                        <div id="content" role="main">
-                            <Switch>
-                                <Route exact path="/">
-                                    <Redirect
-                                        to={`/${homePagePath.join('/')}`}
+                                <button
+                                    id="nav-mobile-settings"
+                                    accessKey="t"
+                                    aria-label={_('settingsbutton')}
+                                    onClick={menuButtonOnClick}
+                                >
+                                    <FontAwesomeIcon
+                                        icon={icons.menu}
+                                        size="2x"
                                     />
-                                </Route>
-                                <Route path={ENTRIES_ROUTE_PATTERN}>
-                                    {(routeProps) => (
-                                        <EntriesPage
-                                            {...routeProps}
-                                            ref={entriesRef}
-                                            setNavExpanded={setNavExpanded}
-                                            configuration={configuration}
-                                            navSourcesExpanded={
-                                                navSourcesExpanded
-                                            }
-                                            unreadItemsCount={unreadItemsCount}
-                                            setGlobalUnreadCount={
-                                                setGlobalUnreadCount
-                                            }
-                                        />
-                                    )}
-                                </Route>
-                                <Route path="/manage/sources">
-                                    <SourcesPage />
-                                </Route>
-                                <Route path="*">
-                                    <NotFound />
-                                </Route>
-                            </Switch>
-                        </div>
-                    </CheckAuthorization>
-                </Route>
+                                </button>
+                            </div>
+
+                            {/* navigation */}
+                            <Collapse
+                                isOpen={!smartphone || navExpanded}
+                                className="collapse-css-transition"
+                            >
+                                <div id="nav" role="navigation">
+                                    <Navigation
+                                        entriesPage={entriesPage}
+                                        setNavExpanded={setNavExpanded}
+                                        navSourcesExpanded={navSourcesExpanded}
+                                        setNavSourcesExpanded={
+                                            setNavSourcesExpanded
+                                        }
+                                        offlineState={offlineState}
+                                        allItemsCount={allItemsCount}
+                                        allItemsOfflineCount={
+                                            allItemsOfflineCount
+                                        }
+                                        unreadItemsCount={unreadItemsCount}
+                                        unreadItemsOfflineCount={
+                                            unreadItemsOfflineCount
+                                        }
+                                        starredItemsCount={starredItemsCount}
+                                        starredItemsOfflineCount={
+                                            starredItemsOfflineCount
+                                        }
+                                        sourcesState={sourcesState}
+                                        setSourcesState={setSourcesState}
+                                        sources={sources}
+                                        setSources={setSources}
+                                        tags={tags}
+                                        reloadAll={reloadAll}
+                                    />
+                                </div>
+                            </Collapse>
+
+                            <ul id="search-list">
+                                <SearchList />
+                            </ul>
+
+                            {/* content */}
+                            <div id="content" role="main">
+                                <Switch>
+                                    <Route
+                                        exact
+                                        path="/"
+                                        render={() => (
+                                            <Redirect
+                                                to={`/${homePagePath.join('/')}`}
+                                            />
+                                        )}
+                                    />
+                                    <Route
+                                        path={ENTRIES_ROUTE_PATTERN}
+                                        render={(routeProps) => (
+                                            <EntriesPage
+                                                {...routeProps}
+                                                ref={entriesRef}
+                                                setNavExpanded={setNavExpanded}
+                                                configuration={configuration}
+                                                navSourcesExpanded={
+                                                    navSourcesExpanded
+                                                }
+                                                unreadItemsCount={
+                                                    unreadItemsCount
+                                                }
+                                                setGlobalUnreadCount={
+                                                    setGlobalUnreadCount
+                                                }
+                                            />
+                                        )}
+                                    />
+                                    <Route
+                                        path="/manage/sources"
+                                        render={() => <SourcesPage />}
+                                    />
+                                    <Route
+                                        path="*"
+                                        render={() => <NotFound />}
+                                    />
+                                </Switch>
+                            </div>
+                        </CheckAuthorization>
+                    )}
+                />
             </Switch>
         </React.StrictMode>
     );

--- a/client/js/templates/EntriesPage.jsx
+++ b/client/js/templates/EntriesPage.jsx
@@ -4,9 +4,10 @@ import React, {
     useEffect,
     useMemo,
     useState,
+    forwardRef,
 } from 'react';
 import PropTypes from 'prop-types';
-import { Link, useLocation, useParams } from 'react-router-dom';
+import { Link, useLocation, useParams, useRouteMatch } from 'react-router-dom';
 import { useOnline } from 'rooks';
 import { useStateWithDeps } from 'use-state-with-deps';
 import nullable from 'prop-types-nullable';
@@ -25,7 +26,11 @@ import { ConfigurationContext } from '../helpers/configuration';
 import { autoScroll, Direction } from '../helpers/navigation';
 import { LocalizationContext } from '../helpers/i18n';
 import { useShouldReload } from '../helpers/hooks';
-import { forceReload, makeEntriesLinkLocation } from '../helpers/uri';
+import {
+    ENTRIES_ROUTE_PATTERN,
+    forceReload,
+    makeEntriesLinkLocation,
+} from '../helpers/uri';
 import { HttpError } from '../errors';
 
 function reloadList({
@@ -539,7 +544,7 @@ const initialState = {
     loadingState: LoadingState.INITIAL,
 };
 
-export default class StateHolder extends React.Component {
+class StateHolder extends React.Component {
     constructor(props) {
         super(props);
         this.state = initialState;
@@ -1238,3 +1243,40 @@ StateHolder.propTypes = {
     setGlobalUnreadCount: PropTypes.func.isRequired,
     unreadItemsCount: PropTypes.number.isRequired,
 };
+
+const StateHolderOuter = forwardRef(function StateHolderOuter(
+    {
+        configuration,
+        setNavExpanded,
+        navSourcesExpanded,
+        setGlobalUnreadCount,
+        unreadItemsCount,
+    },
+    ref,
+) {
+    const location = useLocation();
+    const match = useRouteMatch(ENTRIES_ROUTE_PATTERN);
+
+    return (
+        <StateHolder
+            ref={ref}
+            location={location}
+            match={match}
+            configuration={configuration}
+            setNavExpanded={setNavExpanded}
+            navSourcesExpanded={navSourcesExpanded}
+            setGlobalUnreadCount={setGlobalUnreadCount}
+            unreadItemsCount={unreadItemsCount}
+        />
+    );
+});
+
+StateHolderOuter.propTypes = {
+    configuration: PropTypes.object.isRequired,
+    setNavExpanded: PropTypes.func.isRequired,
+    navSourcesExpanded: PropTypes.bool.isRequired,
+    setGlobalUnreadCount: PropTypes.func.isRequired,
+    unreadItemsCount: PropTypes.number.isRequired,
+};
+
+export default StateHolderOuter;

--- a/client/js/templates/EntriesPage.jsx
+++ b/client/js/templates/EntriesPage.jsx
@@ -827,11 +827,8 @@ class StateHolder extends React.Component {
         this.setExpandedEntries({});
         this.props.setNavExpanded(false);
 
-        if (
-            ids.length !== 0 &&
-            this.props.match.params.filter === FilterType.UNREAD
-        ) {
-            markedEntries = markedEntries.filter(({ id }) => !ids.includes(id));
+        if (this.props.match.params.filter === FilterType.UNREAD) {
+            markedEntries = [];
         }
 
         this.setLoadingState(LoadingState.LOADING);

--- a/client/js/templates/EntriesPage.jsx
+++ b/client/js/templates/EntriesPage.jsx
@@ -7,7 +7,7 @@ import React, {
     forwardRef,
 } from 'react';
 import PropTypes from 'prop-types';
-import { Link, useLocation, useParams } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router';
 import { useOnline } from 'rooks';
 import { useStateWithDeps } from 'use-state-with-deps';
 import nullable from 'prop-types-nullable';
@@ -28,7 +28,7 @@ import { LocalizationContext } from '../helpers/i18n';
 import { useShouldReload } from '../helpers/hooks';
 import { forceReload, makeEntriesLinkLocation } from '../helpers/uri';
 import { HttpError } from '../errors';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 function reloadList({
     fetchParams,

--- a/client/js/templates/EntriesPage.jsx
+++ b/client/js/templates/EntriesPage.jsx
@@ -7,7 +7,13 @@ import React, {
     forwardRef,
 } from 'react';
 import PropTypes from 'prop-types';
-import { Link, useLocation, useParams, useRouteMatch } from 'react-router-dom';
+import {
+    Link,
+    useHistory,
+    useLocation,
+    useParams,
+    useRouteMatch,
+} from 'react-router-dom';
 import { useOnline } from 'rooks';
 import { useStateWithDeps } from 'use-state-with-deps';
 import nullable from 'prop-types-nullable';
@@ -36,6 +42,7 @@ import { HttpError } from '../errors';
 function reloadList({
     fetchParams,
     abortController,
+    history,
     append = false,
     waitForSync = true,
     configuration,
@@ -139,7 +146,7 @@ function reloadList({
                     error instanceof HttpError &&
                     error.response.status === 403
                 ) {
-                    selfoss.history.push('/sign/in', {
+                    history.push('/sign/in', {
                         error: selfoss.app._('error_session_expired'),
                     });
                     return;
@@ -231,6 +238,7 @@ export function EntriesPage({
     const allowedToWrite = useAllowedToWrite();
     const configuration = useContext(ConfigurationContext);
 
+    const history = useHistory();
     const location = useLocation();
     const forceReload = useShouldReload();
     const searchText = useMemo(() => {
@@ -298,6 +306,7 @@ export function EntriesPage({
                 fromId,
             },
             abortController,
+            history,
             append,
             configuration,
             // We do not want to focus the entry on successive loads.
@@ -325,6 +334,7 @@ export function EntriesPage({
         };
     }, [
         configuration,
+        history,
         params.filter,
         currentTag,
         currentSource,
@@ -892,7 +902,7 @@ class StateHolder extends React.Component {
                             error instanceof HttpError &&
                             error.response.status === 403
                         ) {
-                            selfoss.history.push('/sign/in', {
+                            this.props.history.push('/sign/in', {
                                 error: selfoss.app._('error_session_expired'),
                             });
                             return;
@@ -973,7 +983,7 @@ class StateHolder extends React.Component {
                             error instanceof HttpError &&
                             error.response.status === 403
                         ) {
-                            selfoss.history.push('/sign/in', {
+                            this.props.history.push('/sign/in', {
                                 error: selfoss.app._('error_session_expired'),
                             });
                             return;
@@ -1042,7 +1052,7 @@ class StateHolder extends React.Component {
                             error instanceof HttpError &&
                             error.response.status === 403
                         ) {
-                            selfoss.history.push('/sign/in', {
+                            this.props.history.push('/sign/in', {
                                 error: selfoss.app._('error_session_expired'),
                             });
                             return;
@@ -1064,7 +1074,7 @@ class StateHolder extends React.Component {
         /**
          * HACK: A counter that is increased every time reload action (r key) is triggered.
          */
-        selfoss.history.replace({
+        this.props.history.replace({
             ...this.props.location,
             ...makeEntriesLinkLocation(this.props.location, { id: null }),
             state: forceReload(this.props.location),
@@ -1233,6 +1243,7 @@ class StateHolder extends React.Component {
 
 StateHolder.propTypes = {
     configuration: PropTypes.object.isRequired,
+    history: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
     match: PropTypes.object.isRequired,
     setNavExpanded: PropTypes.func.isRequired,
@@ -1251,12 +1262,14 @@ const StateHolderOuter = forwardRef(function StateHolderOuter(
     },
     ref,
 ) {
+    const history = useHistory();
     const location = useLocation();
     const match = useRouteMatch(ENTRIES_ROUTE_PATTERN);
 
     return (
         <StateHolder
             ref={ref}
+            history={history}
             location={location}
             match={match}
             configuration={configuration}

--- a/client/js/templates/HashPassword.jsx
+++ b/client/js/templates/HashPassword.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useInput } from 'rooks';
 import { LoadingState } from '../requests/LoadingState';
 import { HttpError } from '../errors';
@@ -12,7 +12,7 @@ export default function HashPassword({ setTitle }) {
     const [error, setError] = useState(null);
     const passwordEntry = useInput('');
 
-    const history = useHistory();
+    const navigate = useNavigate();
 
     const submit = useCallback(
         (event) => {
@@ -29,7 +29,7 @@ export default function HashPassword({ setTitle }) {
                         error instanceof HttpError &&
                         error.response.status === 403
                     ) {
-                        history.push('/sign/in', {
+                        navigate('/sign/in', {
                             error: 'Generating a new password hash requires being logged in or not setting “password” in selfoss configuration.',
                             returnLocation: '/password',
                         });
@@ -39,7 +39,7 @@ export default function HashPassword({ setTitle }) {
                     setState(LoadingState.ERROR);
                 });
         },
-        [history, passwordEntry.value],
+        [navigate, passwordEntry.value],
     );
 
     useEffect(() => {

--- a/client/js/templates/HashPassword.jsx
+++ b/client/js/templates/HashPassword.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useInput } from 'rooks';
 import { LoadingState } from '../requests/LoadingState';
 import { HttpError } from '../errors';

--- a/client/js/templates/Item.jsx
+++ b/client/js/templates/Item.jsx
@@ -7,7 +7,7 @@ import React, {
     useState,
 } from 'react';
 import PropTypes from 'prop-types';
-import { Link, useNavigate, useLocation } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router';
 import { usePreviousImmediate } from 'rooks';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classNames from 'classnames';

--- a/client/js/templates/LoginForm.jsx
+++ b/client/js/templates/LoginForm.jsx
@@ -2,7 +2,7 @@ import React, { useCallback, useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { SpinnerBig } from './Spinner';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import { HttpError, LoginError } from '../errors';
 import { ConfigurationContext } from '../helpers/configuration';
 import { LocalizationContext } from '../helpers/i18n';

--- a/client/js/templates/LoginForm.jsx
+++ b/client/js/templates/LoginForm.jsx
@@ -2,7 +2,7 @@ import React, { useCallback, useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { SpinnerBig } from './Spinner';
-import { useHistory, useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { HttpError, LoginError } from '../errors';
 import { ConfigurationContext } from '../helpers/configuration';
 import { LocalizationContext } from '../helpers/i18n';
@@ -10,7 +10,7 @@ import { LocalizationContext } from '../helpers/i18n';
 function handleLogIn({
     event,
     configuration,
-    history,
+    navigate,
     setLoading,
     username,
     password,
@@ -24,7 +24,7 @@ function handleLogIn({
     selfoss
         .login({ configuration, username, password, enableOffline })
         .then(() => {
-            history.push(returnLocation);
+            navigate(returnLocation);
         })
         .catch((err) => {
             const message =
@@ -36,8 +36,11 @@ function handleLogIn({
                                   ? `HTTP ${err.response.status} ${err.message}`
                                   : err.message,
                       });
-            history.replace('/sign/in', {
-                error: message,
+            navigate('/sign/in', {
+                replace: true,
+                state: {
+                    error: message,
+                },
             });
         })
         .finally(() => {
@@ -52,7 +55,7 @@ export default function LoginForm({ offlineEnabled }) {
     const [enableOffline, setEnableOffline] = useState(offlineEnabled);
 
     const configuration = useContext(ConfigurationContext);
-    const history = useHistory();
+    const navigate = useNavigate();
     const location = useLocation();
     const error = location?.state?.error;
     const returnLocation = location?.state?.returnLocation ?? '/';
@@ -62,7 +65,7 @@ export default function LoginForm({ offlineEnabled }) {
             handleLogIn({
                 event,
                 configuration,
-                history,
+                navigate,
                 setLoading,
                 username,
                 password,
@@ -71,7 +74,7 @@ export default function LoginForm({ offlineEnabled }) {
             }),
         [
             configuration,
-            history,
+            navigate,
             username,
             password,
             enableOffline,

--- a/client/js/templates/NavFilters.jsx
+++ b/client/js/templates/NavFilters.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useContext, useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useEntriesParams } from '../helpers/uri';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 import classNames from 'classnames';
 import { FilterType } from '../Filter';
 import { makeEntriesLinkLocation, useForceReload } from '../helpers/uri';

--- a/client/js/templates/NavFilters.jsx
+++ b/client/js/templates/NavFilters.jsx
@@ -1,13 +1,10 @@
-import React, { useCallback, useContext, useState } from 'react';
+import React, { useCallback, useContext, useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { Link, useRouteMatch } from 'react-router-dom';
+import { useEntriesParams } from '../helpers/uri';
+import { Link, useLocation } from 'react-router-dom';
 import classNames from 'classnames';
 import { FilterType } from '../Filter';
-import {
-    forceReload,
-    makeEntriesLinkLocation,
-    ENTRIES_ROUTE_PATTERN,
-} from '../helpers/uri';
+import { makeEntriesLinkLocation, useForceReload } from '../helpers/uri';
 import { Collapse } from '@kunukn/react-collapse';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import * as icons from '../icons';
@@ -25,9 +22,8 @@ export default function NavFilters({
 }) {
     const [expanded, setExpanded] = useState(true);
 
-    // useParams does not seem to work.
-    const match = useRouteMatch(ENTRIES_ROUTE_PATTERN);
-    const params = match !== null ? match.params : {};
+    const params = useEntriesParams();
+    const location = useLocation();
 
     const toggleExpanded = useCallback(
         () => setExpanded((expanded) => !expanded),
@@ -39,41 +35,34 @@ export default function NavFilters({
         [setNavExpanded],
     );
 
-    const newestLink = useCallback(
-        (location) => ({
-            ...location,
-            ...makeEntriesLinkLocation(location, {
+    const newestLink = useMemo(
+        () =>
+            makeEntriesLinkLocation(location, {
                 filter: FilterType.NEWEST,
                 id: null,
             }),
-            state: forceReload(location),
-        }),
-        [],
+        [location],
     );
 
-    const unreadLink = useCallback(
-        (location) => ({
-            ...location,
-            ...makeEntriesLinkLocation(location, {
+    const unreadLink = useMemo(
+        () =>
+            makeEntriesLinkLocation(location, {
                 filter: FilterType.UNREAD,
                 id: null,
             }),
-            state: forceReload(location),
-        }),
-        [],
+        [location],
     );
 
-    const starredLink = useCallback(
-        (location) => ({
-            ...location,
-            ...makeEntriesLinkLocation(location, {
+    const starredLink = useMemo(
+        () =>
+            makeEntriesLinkLocation(location, {
                 filter: FilterType.STARRED,
                 id: null,
             }),
-            state: forceReload(location),
-        }),
-        [],
+        [location],
     );
+
+    const forceReload = useForceReload();
 
     const _ = useContext(LocalizationContext);
 
@@ -109,9 +98,10 @@ export default function NavFilters({
                         <Link
                             id="nav-filter-newest"
                             to={newestLink}
+                            state={forceReload}
                             className={classNames({
                                 'nav-filter-newest': true,
-                                active: params.filter === FilterType.NEWEST,
+                                active: params?.filter === FilterType.NEWEST,
                             })}
                             onClick={collapseNav}
                         >
@@ -141,9 +131,10 @@ export default function NavFilters({
                         <Link
                             id="nav-filter-unread"
                             to={unreadLink}
+                            state={forceReload}
                             className={classNames({
                                 'nav-filter-unread': true,
-                                active: params.filter === FilterType.UNREAD,
+                                active: params?.filter === FilterType.UNREAD,
                             })}
                             onClick={collapseNav}
                         >
@@ -187,9 +178,10 @@ export default function NavFilters({
                         <Link
                             id="nav-filter-starred"
                             to={starredLink}
+                            state={forceReload}
                             className={classNames({
                                 'nav-filter-starred': true,
-                                active: params.filter === FilterType.STARRED,
+                                active: params?.filter === FilterType.STARRED,
                             })}
                             onClick={collapseNav}
                         >

--- a/client/js/templates/NavSearch.jsx
+++ b/client/js/templates/NavSearch.jsx
@@ -6,7 +6,7 @@ import React, {
     useState,
 } from 'react';
 import PropTypes from 'prop-types';
-import { useLocation, useHistory } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import classNames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { makeEntriesLink } from '../helpers/uri';
@@ -19,7 +19,7 @@ function handleSubmit({
     setActive,
     searchField,
     searchText,
-    history,
+    navigate,
     location,
     setNavExpanded,
 }) {
@@ -30,7 +30,7 @@ function handleSubmit({
         return;
     }
 
-    history.push(makeEntriesLink(location, { search: searchText, id: null }));
+    navigate(makeEntriesLink(location, { search: searchText, id: null }));
     setActive(false);
     searchField.current.blur();
 
@@ -48,7 +48,7 @@ function handleFieldKeyUp({ event, searchButton, searchRemoveButton }) {
 }
 
 // remove button of search
-function handleRemove({ setActive, searchField, history, location }) {
+function handleRemove({ setActive, searchField, navigate, location }) {
     const queryString = new URLSearchParams(location.search);
     const oldTerm = queryString.get('search');
 
@@ -59,7 +59,7 @@ function handleRemove({ setActive, searchField, history, location }) {
         return;
     }
 
-    history.push(makeEntriesLink(location, { search: '', id: null }));
+    navigate(makeEntriesLink(location, { search: '', id: null }));
 }
 
 export default function NavSearch({ setNavExpanded, offlineState }) {
@@ -70,7 +70,7 @@ export default function NavSearch({ setNavExpanded, offlineState }) {
     const searchRemoveButton = useRef(null);
 
     const location = useLocation();
-    const history = useHistory();
+    const navigate = useNavigate();
 
     const queryString = new URLSearchParams(location.search);
     const oldTerm = queryString.get('search') ?? '';
@@ -96,9 +96,9 @@ export default function NavSearch({ setNavExpanded, offlineState }) {
         [],
     );
 
-    const removeOnClick = useCallback(
-        () => handleRemove({ setActive, searchField, history, location }),
-        [history, location],
+    const removeOnClick = React.useCallback(
+        () => handleRemove({ setActive, searchField, navigate, location }),
+        [navigate, location],
     );
 
     const searchOnClick = useCallback(
@@ -108,11 +108,11 @@ export default function NavSearch({ setNavExpanded, offlineState }) {
                 setActive,
                 searchField,
                 searchText,
-                history,
+                navigate,
                 location,
                 setNavExpanded,
             }),
-        [active, searchText, history, location, setNavExpanded],
+        [active, searchText, navigate, location, setNavExpanded],
     );
 
     const _ = useContext(LocalizationContext);

--- a/client/js/templates/NavSearch.jsx
+++ b/client/js/templates/NavSearch.jsx
@@ -6,7 +6,7 @@ import React, {
     useState,
 } from 'react';
 import PropTypes from 'prop-types';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import classNames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { makeEntriesLink } from '../helpers/uri';

--- a/client/js/templates/NavSources.jsx
+++ b/client/js/templates/NavSources.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 import { usePreviousImmediate } from 'rooks';
 import classNames from 'classnames';
 import { unescape } from 'html-escaper';

--- a/client/js/templates/NavTags.jsx
+++ b/client/js/templates/NavTags.jsx
@@ -1,7 +1,7 @@
 import React, { useContext, useMemo, useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import nullable from 'prop-types-nullable';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 import classNames from 'classnames';
 import { unescape } from 'html-escaper';
 import {

--- a/client/js/templates/NavToolBar.jsx
+++ b/client/js/templates/NavToolBar.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import * as icons from '../icons';
 import {

--- a/client/js/templates/NavToolBar.jsx
+++ b/client/js/templates/NavToolBar.jsx
@@ -10,7 +10,7 @@ import {
 } from '../helpers/authorizations';
 import { ConfigurationContext } from '../helpers/configuration';
 import { LocalizationContext } from '../helpers/i18n';
-import { forceReload } from '../helpers/uri';
+import { useForceReload } from '../helpers/uri';
 
 function handleReloadAll({ reloadAll, setReloading, setNavExpanded }) {
     setReloading(true);
@@ -33,6 +33,7 @@ function handleLogOut({ setNavExpanded }) {
 
 export default function NavToolBar({ reloadAll, setNavExpanded }) {
     const [reloading, setReloading] = useState(false);
+    const forceReload = useForceReload();
 
     const refreshOnClick = useCallback(
         () => handleReloadAll({ reloadAll, setReloading, setNavExpanded }),
@@ -42,15 +43,6 @@ export default function NavToolBar({ reloadAll, setNavExpanded }) {
     const settingsOnClick = useCallback(() => {
         setNavExpanded(false);
     }, [setNavExpanded]);
-
-    const settingsLink = useCallback(
-        (location) => ({
-            ...location,
-            pathname: '/manage/sources',
-            state: forceReload(location),
-        }),
-        [],
-    );
 
     const logoutOnClick = useCallback(
         () => handleLogOut({ setNavExpanded }),
@@ -89,8 +81,9 @@ export default function NavToolBar({ reloadAll, setNavExpanded }) {
                     title={_('settingsbutton')}
                     aria-label={_('settingsbutton')}
                     accessKey="t"
-                    to={settingsLink}
+                    to="/manage/sources"
                     onClick={settingsOnClick}
+                    state={forceReload}
                 >
                     <FontAwesomeIcon icon={icons.settings} fixedWidth />
                 </Link>

--- a/client/js/templates/OpmlImport.jsx
+++ b/client/js/templates/OpmlImport.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useOnline } from 'rooks';
-import { Link, useHistory } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { LoadingState } from '../requests/LoadingState';
 import { HttpError, UnexpectedStateError } from '../errors';
 import { importOpml } from '../requests/common';
@@ -11,7 +11,7 @@ export default function OpmlImport({ setTitle }) {
     const [message, setMessage] = useState(null);
     const fileEntry = useRef();
 
-    const history = useHistory();
+    const navigate = useNavigate();
 
     const submit = useCallback(
         (event) => {
@@ -74,7 +74,7 @@ export default function OpmlImport({ setTitle }) {
                         error instanceof HttpError &&
                         error.response.status === 403
                     ) {
-                        history.push('/sign/in', {
+                        navigate('/sign/in', {
                             error: 'Importing OPML file requires being logged in or not setting “password” in selfoss configuration.',
                             returnLocation: '/opml',
                         });
@@ -92,7 +92,7 @@ export default function OpmlImport({ setTitle }) {
                     }
                 });
         },
-        [history],
+        [navigate],
     );
 
     useEffect(() => {

--- a/client/js/templates/OpmlImport.jsx
+++ b/client/js/templates/OpmlImport.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useOnline } from 'rooks';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 import { LoadingState } from '../requests/LoadingState';
 import { HttpError, UnexpectedStateError } from '../errors';
 import { importOpml } from '../requests/common';

--- a/client/js/templates/SearchList.jsx
+++ b/client/js/templates/SearchList.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { makeEntriesLink } from '../helpers/uri';
 import * as icons from '../icons';

--- a/client/js/templates/SearchList.jsx
+++ b/client/js/templates/SearchList.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { useLocation, useHistory } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { makeEntriesLink } from '../helpers/uri';
 import * as icons from '../icons';
@@ -33,7 +33,7 @@ function joinTerm(words) {
 }
 
 // remove search term
-function handleRemove({ index, location, history, regexSearch }) {
+function handleRemove({ index, location, navigate, regexSearch }) {
     let newterm;
     if (regexSearch) {
         newterm = '';
@@ -46,16 +46,16 @@ function handleRemove({ index, location, history, regexSearch }) {
         newterm = joinTerm(termArray);
     }
 
-    history.push(makeEntriesLink(location, { search: newterm, id: null }));
+    navigate(makeEntriesLink(location, { search: newterm, id: null }));
 }
 
 function SearchWord({ regexSearch, index, item }) {
     const location = useLocation();
-    const history = useHistory();
+    const navigate = useNavigate();
 
     const removeOnClick = useCallback(
-        () => handleRemove({ index, location, history, regexSearch }),
-        [index, location, history, regexSearch],
+        () => handleRemove({ index, location, navigate, regexSearch }),
+        [index, location, navigate, regexSearch],
     );
 
     return (

--- a/client/js/templates/Source.jsx
+++ b/client/js/templates/Source.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useRef } from 'react';
 import { Menu, MenuButton, MenuItem } from '@szhsin/react-menu';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router';
 import { fadeOut } from '@siteparts/show-hide-effects';
 import { makeEntriesLinkLocation } from '../helpers/uri';
 import PropTypes from 'prop-types';

--- a/client/js/templates/Source.jsx
+++ b/client/js/templates/Source.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useRef } from 'react';
 import { Menu, MenuButton, MenuItem } from '@szhsin/react-menu';
-import { useHistory, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { fadeOut } from '@siteparts/show-hide-effects';
 import { makeEntriesLinkLocation } from '../helpers/uri';
 import PropTypes from 'prop-types';
@@ -606,7 +606,7 @@ export default function Source({
         [source.id, setDirtySources],
     );
 
-    const history = useHistory();
+    const navigate = useNavigate();
     const location = useLocation();
 
     const sourceElem = useRef(null);
@@ -622,14 +622,14 @@ export default function Source({
                     setDirty,
                 });
             } else if (value === 'browse') {
-                history.push(
+                navigate(
                     makeEntriesLinkLocation(location, {
                         category: `source-${source.id}`,
                     }),
                 );
             }
         },
-        [source, sourceElem, setSources, setDirty, location, history],
+        [source, sourceElem, setSources, setDirty, location, navigate],
     );
 
     const _ = useContext(LocalizationContext);

--- a/client/js/templates/SourcesPage.jsx
+++ b/client/js/templates/SourcesPage.jsx
@@ -49,6 +49,7 @@ function handleAddSource({
 // load sources
 function loadSources({
     abortController,
+    history,
     location,
     setSpouts,
     setSources,
@@ -95,7 +96,7 @@ function loadSources({
                     error instanceof HttpError &&
                     error.response.status === 403
                 ) {
-                    selfoss.history.push('/sign/in', {
+                    history.push('/sign/in', {
                         error: selfoss.app._('error_session_expired'),
                     });
                     return;
@@ -127,6 +128,7 @@ export default function SourcesPage() {
 
         loadSources({
             abortController,
+            history,
             location,
             setSpouts,
             setSources,

--- a/client/js/templates/SourcesPage.jsx
+++ b/client/js/templates/SourcesPage.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useMemo } from 'react';
-import { Link, useNavigate, useLocation, useMatch } from 'react-router-dom';
+import { Link, useNavigate, useLocation, useMatch } from 'react-router';
 import Source from './Source';
 import { SpinnerBig } from './Spinner';
 import { LoadingState } from '../requests/LoadingState';

--- a/client/js/templates/SourcesPage.jsx
+++ b/client/js/templates/SourcesPage.jsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { useMemo } from 'react';
-import { Prompt } from 'react-router';
-import { Link, useHistory, useLocation, useRouteMatch } from 'react-router-dom';
+import { Link, useNavigate, useLocation, useMatch } from 'react-router-dom';
 import Source from './Source';
 import { SpinnerBig } from './Spinner';
 import { LoadingState } from '../requests/LoadingState';
@@ -49,8 +48,8 @@ function handleAddSource({
 // load sources
 function loadSources({
     abortController,
-    history,
     location,
+    navigate,
     setSpouts,
     setSources,
     setLoadingState,
@@ -96,8 +95,10 @@ function loadSources({
                     error instanceof HttpError &&
                     error.response.status === 403
                 ) {
-                    history.push('/sign/in', {
-                        error: selfoss.app._('error_session_expired'),
+                    navigate('/sign/in', {
+                        state: {
+                            error: selfoss.app._('error_session_expired'),
+                        },
                     });
                     return;
                 }
@@ -119,17 +120,17 @@ export default function SourcesPage() {
 
     const forceReload = useShouldReload();
 
-    const history = useHistory();
+    const navigate = useNavigate();
     const location = useLocation();
-    const isAdding = useRouteMatch('/manage/sources/add');
+    const isAdding = useMatch('/manage/sources/add');
 
     useEffect(() => {
         const abortController = new AbortController();
 
         loadSources({
             abortController,
-            history,
             location,
+            navigate,
             setSpouts,
             setSources,
             setLoadingState,
@@ -148,7 +149,7 @@ export default function SourcesPage() {
                 });
 
                 // Clear the value from the state so it does not bug us forever.
-                history.replace('/manage/sources');
+                navigate('/manage/sources');
             }
         });
 
@@ -157,7 +158,7 @@ export default function SourcesPage() {
         };
     }, [
         forceReload,
-        // location.search and history are intentionally omitted
+        // location.search and navigate are intentionally omitted
         // to prevent reloading when the presets are cleaned from the URL.
     ]);
 
@@ -169,10 +170,17 @@ export default function SourcesPage() {
     const _ = useContext(LocalizationContext);
 
     const [dirtySources, setDirtySources] = useState({});
+    // eslint-disable-next-line no-unused-vars
     const isDirty = useMemo(
         () => Object.values(dirtySources).includes(true),
         [dirtySources],
     );
+
+    // TODO: Error: useBlocker must be used within a data router.  See https://reactrouter.com/v6/routers/picking-a-router.
+    // usePrompt({
+    //     when: isDirty,
+    //     message: _('sources_leaving_unsaved_prompt'),
+    // });
 
     if (loadingState === LoadingState.LOADING) {
         return <SpinnerBig label={_('sources_loading')} />;
@@ -184,11 +192,6 @@ export default function SourcesPage() {
 
     return (
         <React.Fragment>
-            <Prompt
-                when={isDirty}
-                message={_('sources_leaving_unsaved_prompt')}
-            />
-
             <button className="source-add" onClick={addOnClick}>
                 {_('source_add')}
             </button>

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -26,7 +26,7 @@
         "ramda": "^0.30.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^5.2.0",
+        "react-router-dom": "^6.28.1",
         "reset-css": "^5.0.1",
         "rooks": "^7.1.1",
         "tinykeys": "^3.0.0",
@@ -75,18 +75,6 @@
       "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2294,6 +2282,15 @@
         "@parcel/core": "^2.13.3"
       }
     },
+    "node_modules/@remix-run/router": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.21.0.tgz",
+      "integrity": "sha512-xfSkCAchbdG5PnbrKqFWwia4Bi61nH+wm8wLEqfHDyp7Y3dZzgqS2itV8i4gAq9pC2HsTpwyBC6Ds8VHZ96JlA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@siteparts/show-hide-effects": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@siteparts/show-hide-effects/-/show-hide-effects-1.0.0.tgz",
@@ -4410,29 +4407,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -4990,12 +4964,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5965,15 +5933,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/path-to-regexp": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
-      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -6435,41 +6394,35 @@
       }
     },
     "node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.28.1.tgz",
+      "integrity": "sha512-2omQTA3rkMljmrvvo6WtewGdVh45SpL9hGiCI9uUrwGGfNFDIvGK4gYJsKlJoNVi6AQZcopSCballL+QGOm7fA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.21.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.28.1.tgz",
+      "integrity": "sha512-YraE27C/RdjcZwl5UCqF/ffXnZDxpJdk9Q6jw38SZHjXs7NNdpViq2l2c7fO7+4uWaEfcwfGCv3RSg4e1By/fQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.21.0",
+        "react-router": "6.28.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-transition-state": {
@@ -6523,6 +6476,7 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
@@ -6587,12 +6541,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
-      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.0.4",
@@ -7447,18 +7395,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "license": "MIT"
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-      "license": "MIT"
-    },
     "node_modules/tinykeys": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tinykeys/-/tinykeys-3.0.0.tgz",
@@ -7689,12 +7625,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
-      "license": "MIT"
     },
     "node_modules/weak-lru-cache": {
       "version": "1.2.2",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -26,7 +26,7 @@
         "ramda": "^0.30.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.28.1",
+        "react-router": "^7.1.1",
         "reset-css": "^5.0.1",
         "rooks": "^7.1.1",
         "tinykeys": "^3.0.0",
@@ -2282,15 +2282,6 @@
         "@parcel/core": "^2.13.3"
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.21.0.tgz",
-      "integrity": "sha512-xfSkCAchbdG5PnbrKqFWwia4Bi61nH+wm8wLEqfHDyp7Y3dZzgqS2itV8i4gAq9pC2HsTpwyBC6Ds8VHZ96JlA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@siteparts/show-hide-effects": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@siteparts/show-hide-effects/-/show-hide-effects-1.0.0.tgz",
@@ -2546,6 +2537,12 @@
         "react": ">=16.14.0",
         "react-dom": ">=16.14.0"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",
@@ -3101,6 +3098,15 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/core-js": {
       "version": "3.39.0",
@@ -6394,35 +6400,27 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.28.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.28.1.tgz",
-      "integrity": "sha512-2omQTA3rkMljmrvvo6WtewGdVh45SpL9hGiCI9uUrwGGfNFDIvGK4gYJsKlJoNVi6AQZcopSCballL+QGOm7fA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.1.1.tgz",
+      "integrity": "sha512-39sXJkftkKWRZ2oJtHhCxmoCrBCULr/HAH4IT5DHlgu/Q0FCPV0S4Lx+abjDTx/74xoZzNYDYbOZWlJjruyuDQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.21.0"
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.28.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.28.1.tgz",
-      "integrity": "sha512-YraE27C/RdjcZwl5UCqF/ffXnZDxpJdk9Q6jw38SZHjXs7NNdpViq2l2c7fO7+4uWaEfcwfGCv3RSg4e1By/fQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.21.0",
-        "react-router": "6.28.1"
+        "react": ">=18",
+        "react-dom": ">=18"
       },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-transition-state": {
@@ -6704,6 +6702,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -7420,6 +7424,12 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
+      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,7 @@
     "ramda": "^0.30.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.28.1",
+    "react-router": "^7.1.1",
     "reset-css": "^5.0.1",
     "rooks": "^7.1.1",
     "tinykeys": "^3.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,7 @@
     "ramda": "^0.30.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^5.2.0",
+    "react-router-dom": "^6.28.1",
     "reset-css": "^5.0.1",
     "rooks": "^7.1.1",
     "tinykeys": "^3.0.0",


### PR DESCRIPTION
~~Unfortunately, regular expressions in routes are no longer supported so URLs like `/newest/source-2/143` or `/unread/tag-news/259` will no longer work. We will need to switch them to something like `/sources/2?filter=newest#143` and that will collide with the server API, so it will need to be moved to `/api/` subdirectory.~~ I managed to work around https://github.com/remix-run/react-router/issues/8254 with intermediary `EntriesFilter` component with a custom validation logic.

Though I do not really like the direction of the library towards frameworkization.
