### PR TITLE
spouts\rss\feed: Work around SimplePie returning incorrect date value

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 ### Known regressions
 - Values in `config.ini` containing special characters need to be quoted. Will be fixed by <https://github.com/fossar/selfoss/commit/ba9339372a7bc0678c6c1f74336406ab1bbb4ecb>.
 - Updating sources that already contain items will fail on PHP < 7.2.0. Will be fixed by <https://github.com/fossar/selfoss/commit/d6e9bc8b01a7d58630772f6dc9938e88a28be706>.
+- Updating RSS sources without a valid date fails. Will be fixed by [#1385](https://github.com/fossar/selfoss/pull/1385).
 
 ### New features
 - Thumbnails can be disabled ([#897](https://github.com/fossar/selfoss/pull/897))

--- a/src/spouts/rss/feed.php
+++ b/src/spouts/rss/feed.php
@@ -104,7 +104,8 @@ class feed extends \spouts\spout {
             $icon = null;
             $link = htmlspecialchars_decode((string) $item->get_link(), ENT_COMPAT); // SimplePie sanitizes URLs
             $unixDate = $item->get_date('U');
-            $date = $unixDate !== null ? new \DateTimeImmutable('@' . $unixDate) : new \DateTimeImmutable();
+            // TODO: remove the `false` check once we upgrade to SimplePie 1.8
+            $date = $unixDate !== null && $unixDate !== false ? new \DateTimeImmutable('@' . $unixDate) : new \DateTimeImmutable();
             $author = $this->getAuthorString($item);
 
             yield new Item(


### PR DESCRIPTION
When SimplePie is unable to parse an item update date, it will return `false`, breaking the promise in PHPDoc. Since we do not expect it, we would try to treat the non-null value as a an int and try to create a date object from it, which lead to the affected sources failing to update with the following error:

    Exception: DateTimeImmutable::__construct(): Failed to parse time string (@) at position 0 (@)

I have created an upstream PR:

https://github.com/simplepie/simplepie/pull/753

But until that is available, let’s work around the issue by also guarding against `false`.

Closes: https://github.com/fossar/selfoss/issues/1384
