### PR TITLE
ci: Fix PHPStan

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,10 +28,11 @@ jobs:
           - '7.3'
           - '7.2'
         include:
+          - php: '7.4'
+            phpstan: true
           - php: '7.2'
             cs_fixer: true
             lint_js: true
-            phpstan: true
           - php: '8.2'
             storage: mysql
           - php: '8.2'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,7 +17,7 @@ parameters:
 
         # Bad PHPStan typing rules.
         - '(Parameter #3 \$namespace of method XMLWriter::writeAttributeNs\(\) expects string, null given\.)'
-        - '(Parameter #2 \$algo of function password_hash expects int, string given\.)'
+        - '(Parameter #2 \$algo of function password_hash expects int, string given\.)' # Only fails on PHP ≥ 7.4
 
     typeAliases:
         SpoutParameterInfo: 'array{title: string, type: spouts\Parameter::TYPE_*, default: string, required: bool, validation: array<spouts\Parameter::VALIDATION_*>, values?: array<string, string>}'


### PR DESCRIPTION
The “Parameter #2 $algo of function password_hash expects int, string given.” error only occurs on PHP ≥ 7.4 so running PHPStan with PHP 7.2 would fail with “Error: Ignored error pattern (Parameter #2 \$algo of function password_hash expects int, string given\.) was not matched in reported errors.”
