### PR TITLE
Add 'Share on Mastodon' functionality

### DIFF
--- a/assets/js/icons.js
+++ b/assets/js/icons.js
@@ -6,6 +6,7 @@ import { faFacebookSquare } from '@fortawesome/free-brands-svg-icons/faFacebookS
 import { faGetPocket } from '@fortawesome/free-brands-svg-icons/faGetPocket';
 import { faTwitter } from '@fortawesome/free-brands-svg-icons/faTwitter';
 import { faWordpressSimple } from '@fortawesome/free-brands-svg-icons/faWordpressSimple';
+import { faMastodon } from '@fortawesome/free-brands-svg-icons/faMastodon';
 import { faCheckCircle as faCheckCircleRegular } from '@fortawesome/free-regular-svg-icons/faCheckCircle';
 import { faStar as faStarRegular } from '@fortawesome/free-regular-svg-icons/faStar';
 import { faTimesCircle } from '@fortawesome/free-regular-svg-icons/faTimesCircle';
@@ -48,6 +49,7 @@ export {
     faGetPocket as pocket,
     faTwitter as twitter,
     faWordpressSimple as wordpress,
+    faMastodon as mastodon,
     faCheckCircleRegular as markUnread,
     faStarRegular as star,
     faTimesCircle as close,

--- a/assets/js/sharers.jsx
+++ b/assets/js/sharers.jsx
@@ -58,6 +58,15 @@ export function useSharers({ configuration, _ }) {
                     },
                 },
 
+                'm': {
+                    label: _('share_mastodon_label'),
+                    icon: <FontAwesomeIcon icon={icons.mastodon} />,
+                    action: ({url, title}) => {
+                        window.open(configuration.mastodon + '/share?text=' + encodeURIComponent('"' + title + '"\n' + url), undefined, 'noreferrer');
+                    },
+                    available: configuration.mastodon !== null,
+                },
+
                 'p': {
                     label: _('share_pocket_label'),
                     icon: <FontAwesomeIcon icon={icons.pocket} />,

--- a/assets/locale/de.json
+++ b/assets/locale/de.json
@@ -86,6 +86,7 @@
   "lang_share_diaspora_label": "auf Diaspora teilen",
   "lang_share_twitter_label": "auf Twitter teilen",
   "lang_share_facebook_label": "auf Facebook teilen",
+  "lang_share_mastodon_label": "auf Mastodon teilen",
   "lang_share_pocket_label": "in Pocket speichern",
   "lang_share_wallabag_label": "in Wallabag speichern",
   "lang_share_wordpress_label": "teile auf WordPress",

--- a/assets/locale/en.json
+++ b/assets/locale/en.json
@@ -25,6 +25,7 @@
   "lang_share_diaspora_label": "Share on Diaspora",
   "lang_share_twitter_label": "Share on Twitter",
   "lang_share_facebook_label": "Share on Facebook",
+  "lang_share_mastodon_label": "Share on Mastodon",
   "lang_share_pocket_label": "Save to Pocket",
   "lang_share_wallabag_label": "Save to Wallabag",
   "lang_share_wordpress_label": "Share on WordPress",

--- a/docs/content/docs/administration/options.md
+++ b/docs/content/docs/administration/options.md
@@ -217,6 +217,7 @@ Set to `1` to allow public access for `/update` (anybody can access and start th
 <dt><code>t</code></dt><dd>Twitter</dd>
 <dt><code>p</code></dt><dd>Pocket</dd>
 <dt><code>d</code></dt><dd>Diaspora</dd>
+<dt><code>m</code></dt><dd>Mastodon (requires <a href="#mastodon"><code>mastodon</code></a> option to be set)</dd>
 <dt><code>w</code></dt><dd>Wallabag (requires <a href="#wallabag"><code>wallabag</code></a> option to be set)</dd>
 <dt><code>s</code></dt><dd>Wordpress (requires <a href="#wordpress"><code>wordpress</code></a> option to be set)</dd>
 <dt><code>e</code></dt><dd>E-mail</dd>
@@ -226,6 +227,12 @@ Set to `1` to allow public access for `/update` (anybody can access and start th
 Include the letters for methods you want to use. For example, if you would like to only show Facebook and Twitter share buttons, use `share=ft`.
 
 Defaults to `share=atfpde`.
+</div>
+
+### `mastodon`
+<div class="config-option">
+
+URL of your Mastodon instance, for example `https://example.com`.
 </div>
 
 ### `wallabag`

--- a/src/controllers/About.php
+++ b/src/controllers/About.php
@@ -45,6 +45,7 @@ class About {
                 'share' => $this->configuration->share, // string
                 'wallabag' => $wallabag, // ?array
                 'wordpress' => $this->configuration->wordpress, // ?string
+                'mastodon' => $this->configuration->mastodon, // ?string
                 'autoMarkAsRead' => $this->configuration->autoMarkAsRead, // bool
                 'autoCollapse' => $this->configuration->autoCollapse, // bool
                 'autoStreamMore' => $this->configuration->autoStreamMore, // bool

--- a/src/helpers/Configuration.php
+++ b/src/helpers/Configuration.php
@@ -158,6 +158,9 @@ class Configuration {
     /** @var ?string */
     public $wordpress = null;
 
+    /** @var ?string */
+    public $mastodon = null;
+
     /** @var bool */
     public $allowPublicUpdateAccess = false;
 


### PR DESCRIPTION
Given the recent influx of users on Mastodon, I thought it would be nice to add a "Share on Mastodon" button.

As users are on different mastodon instances with different URLs, we need a new Configuration option to store the URL of the mastodon instance.
I added the option description to the documentation and the English and German translation for the label.

![image](https://user-images.githubusercontent.com/3979034/224515846-34e7d6bd-3504-4bdb-94cd-90fb7ca14d04.png)

The link leads to a page on which the user can edit and publish the mastodon post, pre-filled with the entries title in quotes and its URL.

What do you think?