### PR TITLE
Improve filter support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 - YouTube spout now includes the video description. ([#1412](https://github.com/fossar/selfoss/pull/1412))
 - Mastodon share button was added. Can be enabled by adding `m` to `share` and setting `mastodon` pointing to your chosen instance. ([#1421](https://github.com/fossar/selfoss/pull/1421))
 - Source filters can be negated, or limited to only title or only content. ([#1423](https://github.com/fossar/selfoss/pull/1423))
-- Sources can be filtered based on item’s author. ([#1423](https://github.com/fossar/selfoss/pull/1423))
+- Sources can be filtered based on item’s author or categories. ([#1423](https://github.com/fossar/selfoss/pull/1423))
 
 ### Bug fixes
 - Configuration parser was changed to *raw* method, which relaxes the requirement to quote option values containing special characters in `config.ini`. ([#1371](https://github.com/fossar/selfoss/issues/1371))

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 - Mastodon share button was added. Can be enabled by adding `m` to `share` and setting `mastodon` pointing to your chosen instance. ([#1421](https://github.com/fossar/selfoss/pull/1421))
 - Source filters can be negated, or limited to only title or only content. ([#1423](https://github.com/fossar/selfoss/pull/1423))
 - Sources can be filtered based on item’s author or categories. ([#1423](https://github.com/fossar/selfoss/pull/1423))
+- Source filter expression is now validated whenever a source is modified. ([#1423](https://github.com/fossar/selfoss/pull/1423))
 
 ### Bug fixes
 - Configuration parser was changed to *raw* method, which relaxes the requirement to quote option values containing special characters in `config.ini`. ([#1371](https://github.com/fossar/selfoss/issues/1371))

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 - YouTube spout now accepts handles (starting with `@` sign). ([#1412](https://github.com/fossar/selfoss/pull/1412))
 - YouTube spout now includes the video description. ([#1412](https://github.com/fossar/selfoss/pull/1412))
 - Mastodon share button was added. Can be enabled by adding `m` to `share` and setting `mastodon` pointing to your chosen instance. ([#1421](https://github.com/fossar/selfoss/pull/1421))
-- Source filters can be limited to only title or only content. ([#1423](https://github.com/fossar/selfoss/pull/1423))
+- Source filters can be negated, or limited to only title or only content. ([#1423](https://github.com/fossar/selfoss/pull/1423))
 
 ### Bug fixes
 - Configuration parser was changed to *raw* method, which relaxes the requirement to quote option values containing special characters in `config.ini`. ([#1371](https://github.com/fossar/selfoss/issues/1371))

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@
 - Password hashing helper page will delegate the hashing to server again. ([#1401](https://github.com/fossar/selfoss/pull/1401))
 - Back-end source code is now checked using [PHPStan](https://phpstan.org/). ([#1409](https://github.com/fossar/selfoss/pull/1409))
 - Content Extraction spout will no longer try to extract content we have already extracted. ([#1413](https://github.com/fossar/selfoss/pull/1413))
+- Source filters are stricter, they need to start and end with a `/`. ([#1423](https://github.com/fossar/selfoss/pull/1423))
 
 ## 2.19 – 2022-10-12
 **This version requires PHP ~~5.6~~ 7.2 (see known regressions section) or newer. It is also the last version to support PHP 7.**

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 - YouTube spout now includes the video description. ([#1412](https://github.com/fossar/selfoss/pull/1412))
 - Mastodon share button was added. Can be enabled by adding `m` to `share` and setting `mastodon` pointing to your chosen instance. ([#1421](https://github.com/fossar/selfoss/pull/1421))
 - Source filters can be negated, or limited to only title or only content. ([#1423](https://github.com/fossar/selfoss/pull/1423))
+- Sources can be filtered based on item’s author. ([#1423](https://github.com/fossar/selfoss/pull/1423))
 
 ### Bug fixes
 - Configuration parser was changed to *raw* method, which relaxes the requirement to quote option values containing special characters in `config.ini`. ([#1371](https://github.com/fossar/selfoss/issues/1371))

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - YouTube spout now accepts handles (starting with `@` sign). ([#1412](https://github.com/fossar/selfoss/pull/1412))
 - YouTube spout now includes the video description. ([#1412](https://github.com/fossar/selfoss/pull/1412))
 - Mastodon share button was added. Can be enabled by adding `m` to `share` and setting `mastodon` pointing to your chosen instance. ([#1421](https://github.com/fossar/selfoss/pull/1421))
+- Source filters can be limited to only title or only content. ([#1423](https://github.com/fossar/selfoss/pull/1423))
 
 ### Bug fixes
 - Configuration parser was changed to *raw* method, which relaxes the requirement to quote option values containing special characters in `config.ini`. ([#1371](https://github.com/fossar/selfoss/issues/1371))

--- a/docs/content/docs/usage/filters.md
+++ b/docs/content/docs/usage/filters.md
@@ -11,4 +11,5 @@ The filter expression can take one of the following forms:
 2. A *field-specific filter*: an *atomic filter* preceded by one of the field names below and a colon:
     - `title:/regex/` will keep only items whose title matches the regular expression between the slashes.
     - `content:/regex/` will keep only items whose content matches the regular expression between the slashes.
+    - `author:/regex/` will keep only items which have an author that matches the regular expression between the slashes.
 3. A *negated filter* is either an *atomic filter* or a *field-specific filter* preceded by an exclamation mark (`!`). It will only keep items would not be kept by the filter after the exclamation mark.

--- a/docs/content/docs/usage/filters.md
+++ b/docs/content/docs/usage/filters.md
@@ -12,4 +12,5 @@ The filter expression can take one of the following forms:
     - `title:/regex/` will keep only items whose title matches the regular expression between the slashes.
     - `content:/regex/` will keep only items whose content matches the regular expression between the slashes.
     - `author:/regex/` will keep only items which have an author that matches the regular expression between the slashes.
+    - `category:/regex/` will keep only items which have a category that matches the regular expression between the slashes.
 3. A *negated filter* is either an *atomic filter* or a *field-specific filter* preceded by an exclamation mark (`!`). It will only keep items would not be kept by the filter after the exclamation mark.

--- a/docs/content/docs/usage/filters.md
+++ b/docs/content/docs/usage/filters.md
@@ -8,3 +8,6 @@ You can limit which items of sources will be stored in the database by specifyin
 The filter expression can take one of the following forms:
 
 1. An *atomic filter*: a Perl-compatible regular expression, as [accepted by PHP](https://www.php.net/manual/en/reference.pcre.pattern.syntax.php), between forward slashes (`/`). For example, `/reg(ular expression|ex)/` will keep only items whose title or content matches the regular expression between the slashes (i.e. contain the phrase “regular expression” or “regex”). Learn more about regular expressions on <https://www.regular-expressions.info/>.
+2. A *field-specific filter*: an *atomic filter* preceded by one of the field names below and a colon:
+    - `title:/regex/` will keep only items whose title matches the regular expression between the slashes.
+    - `content:/regex/` will keep only items whose content matches the regular expression between the slashes.

--- a/docs/content/docs/usage/filters.md
+++ b/docs/content/docs/usage/filters.md
@@ -11,3 +11,4 @@ The filter expression can take one of the following forms:
 2. A *field-specific filter*: an *atomic filter* preceded by one of the field names below and a colon:
     - `title:/regex/` will keep only items whose title matches the regular expression between the slashes.
     - `content:/regex/` will keep only items whose content matches the regular expression between the slashes.
+3. A *negated filter* is either an *atomic filter* or a *field-specific filter* preceded by an exclamation mark (`!`). It will only keep items would not be kept by the filter after the exclamation mark.

--- a/docs/content/docs/usage/filters.md
+++ b/docs/content/docs/usage/filters.md
@@ -1,0 +1,10 @@
++++
+title = "Filtering sources"
+weight = 40
++++
+
+You can limit which items of sources will be stored in the database by specifying a filter expression in the “Filter” field of a source on the Settings page.
+
+The filter expression can take one of the following forms:
+
+1. An *atomic filter*: a Perl-compatible regular expression, as [accepted by PHP](https://www.php.net/manual/en/reference.pcre.pattern.syntax.php), between forward slashes (`/`). For example, `/reg(ular expression|ex)/` will keep only items whose title or content matches the regular expression between the slashes (i.e. contain the phrase “regular expression” or “regex”). Learn more about regular expressions on <https://www.regular-expressions.info/>.

--- a/src/controllers/Sources/Write.php
+++ b/src/controllers/Sources/Write.php
@@ -6,6 +6,8 @@ namespace controllers\Sources;
 
 use helpers\Authentication;
 use helpers\ContentLoader;
+use helpers\Filters\FilterFactory;
+use helpers\Filters\FilterSyntaxError;
 use helpers\Misc;
 use helpers\Request;
 use helpers\SpoutLoader;
@@ -96,6 +98,13 @@ class Write {
         $tags = array_map('htmlspecialchars', $data['tags']);
         $spout = $data['spout'];
         $filter = $data['filter'];
+
+        try {
+            // Try to create a filter object for validation.
+            FilterFactory::fromString($filter ?? '');
+        } catch (FilterSyntaxError $exception) {
+            $this->view->jsonError(['filter' => $exception->getMessage()]);
+        }
 
         unset($data['title']);
         unset($data['spout']);

--- a/src/helpers/Filters/AcceptingFilter.php
+++ b/src/helpers/Filters/AcceptingFilter.php
@@ -1,0 +1,24 @@
+<?php
+
+// SPDX-FileCopyrightText: 2023 Jan Tojnar <jtojnar@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace helpers\Filters;
+
+use spouts\Item;
+
+/**
+ * Filter that always admits an item.
+ *
+ * @implements Filter<mixed>
+ */
+final class AcceptingFilter implements Filter {
+    /**
+     * @param mixed $item
+     */
+    public function admits($item): bool {
+        return true;
+    }
+}

--- a/src/helpers/Filters/DisjunctionFilter.php
+++ b/src/helpers/Filters/DisjunctionFilter.php
@@ -1,0 +1,39 @@
+<?php
+
+// SPDX-FileCopyrightText: 2023 Jan Tojnar <jtojnar@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace helpers\Filters;
+
+/**
+ * Filter that admits a list of items iff the inner filter admits any of them.
+ *
+ * @template T
+ * @implements Filter<array<T>>
+ */
+final class DisjunctionFilter implements Filter {
+    /** @var Filter<T> */
+    private $filter;
+
+    /**
+     * @param Filter<T> $filter
+     */
+    public function __construct($filter) {
+        $this->filter = $filter;
+    }
+
+    /**
+     * @param array<T> $items
+     */
+    public function admits($items): bool {
+        foreach ($items as $item) {
+            if ($this->filter->admits($item)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/helpers/Filters/Filter.php
+++ b/src/helpers/Filters/Filter.php
@@ -1,0 +1,29 @@
+<?php
+
+// SPDX-FileCopyrightText: 2023 Jan Tojnar <jtojnar@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace helpers\Filters;
+
+use spouts\Item;
+
+/**
+ * Represents a predicate function.
+ *
+ * Mainly meant to be used for removing items from sources,
+ * when the template parameter is instantiated to `Item`.
+ *
+ * @template T
+ */
+interface Filter {
+    /**
+     * Checks if a value matches the filter.
+     *
+     * @param T $item
+     *
+     * @return bool indicating filter success
+     */
+    public function admits($item): bool;
+}

--- a/src/helpers/Filters/FilterFactory.php
+++ b/src/helpers/Filters/FilterFactory.php
@@ -39,8 +39,10 @@ final class FilterFactory {
             $filter = new MapFilter($filter, Closure::fromCallable([self::class, 'getContentString']));
         } elseif ($field === 'author') {
             $filter = new MapFilter(new DisjunctionFilter($filter), Closure::fromCallable([self::class, 'getAuthors']));
+        } elseif ($field === 'category') {
+            $filter = new MapFilter(new DisjunctionFilter($filter), Closure::fromCallable([self::class, 'getCategories']));
         } else {
-            throw new FilterSyntaxError("Invalid filter expression {$expression}, field must be one of “title”, “content” or “author”.");
+            throw new FilterSyntaxError("Invalid filter expression {$expression}, field must be one of “title”, “content”, “author” or “category”.");
         }
 
         if ($match['negated'] === '!') {
@@ -85,5 +87,28 @@ final class FilterFactory {
         $author = $item->getAuthor();
 
         return $author === null ? [] : [$author];
+    }
+
+    /**
+     * @param Item<mixed> $item
+     *
+     * @return string[]
+     */
+    private static function getCategories(Item $item): array {
+        $extraData = $item->getExtraData();
+        if ($extraData instanceof \SimplePie\Item) {
+            $categories = [];
+            foreach ($extraData->get_categories() ?? [] as $category) {
+                $label = $category->get_label();
+                if ($label !== null) {
+                    $categories[] = $label;
+                }
+            }
+
+            return $categories;
+        }
+
+        // We do not know how to extract categories.
+        return [];
     }
 }

--- a/src/helpers/Filters/FilterFactory.php
+++ b/src/helpers/Filters/FilterFactory.php
@@ -24,7 +24,7 @@ final class FilterFactory {
             return new AcceptingFilter();
         }
 
-        if (@preg_match('/^(?:(?P<field>[^:]*):)?(?P<regex>.+)$/', $expression, $match) === 0) {
+        if (@preg_match('/^(?P<negated>!)?(?:(?P<field>[^:]*):)?(?P<regex>.+)$/', $expression, $match) === 0) {
             throw new FilterSyntaxError("Invalid filter expression {$expression}, see https://selfoss.aditu.de/docs/usage/filters/");
         }
 
@@ -39,6 +39,10 @@ final class FilterFactory {
             $filter = new MapFilter($filter, Closure::fromCallable([self::class, 'getContentString']));
         } else {
             throw new FilterSyntaxError("Invalid filter expression {$expression}, field must be one of “title” or “content”.");
+        }
+
+        if ($match['negated'] === '!') {
+            $filter = new NegationFilter($filter);
         }
 
         return $filter;

--- a/src/helpers/Filters/FilterFactory.php
+++ b/src/helpers/Filters/FilterFactory.php
@@ -1,0 +1,57 @@
+<?php
+
+// SPDX-FileCopyrightText: 2023 Jan Tojnar <jtojnar@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace helpers\Filters;
+
+use Closure;
+use spouts\Item;
+
+final class FilterFactory {
+    /**
+     * Creates a filter based on filter expression language.
+     * See [filter docs](https://selfoss.aditu.de/docs/usage/filters/).
+     *
+     * @throws FilterSyntaxError when the expression is not valid
+     *
+     * @return Filter<Item<mixed>>
+     */
+    public static function fromString(string $expression): Filter {
+        if ($expression === '') {
+            return new AcceptingFilter();
+        }
+
+        $filter = new RegexFilter($expression);
+
+        return new MapFilter(new DisjunctionFilter($filter), Closure::fromCallable([self::class, 'getTitleAndContentStrings']));
+    }
+
+    /**
+     * @param Item<mixed> $item
+     *
+     * @return array{string, string}
+     */
+    private static function getTitleAndContentStrings(Item $item): array {
+        return [
+            self::getTitleString($item),
+            self::getContentString($item),
+        ];
+    }
+
+    /**
+     * @param Item<mixed> $item
+     */
+    private static function getTitleString(Item $item): string {
+        return $item->getTitle()->getRaw();
+    }
+
+    /**
+     * @param Item<mixed> $item
+     */
+    private static function getContentString(Item $item): string {
+        return $item->getContent()->getRaw();
+    }
+}

--- a/src/helpers/Filters/FilterFactory.php
+++ b/src/helpers/Filters/FilterFactory.php
@@ -37,8 +37,10 @@ final class FilterFactory {
             $filter = new MapFilter($filter, Closure::fromCallable([self::class, 'getTitleString']));
         } elseif ($field === 'content') {
             $filter = new MapFilter($filter, Closure::fromCallable([self::class, 'getContentString']));
+        } elseif ($field === 'author') {
+            $filter = new MapFilter(new DisjunctionFilter($filter), Closure::fromCallable([self::class, 'getAuthors']));
         } else {
-            throw new FilterSyntaxError("Invalid filter expression {$expression}, field must be one of “title” or “content”.");
+            throw new FilterSyntaxError("Invalid filter expression {$expression}, field must be one of “title”, “content” or “author”.");
         }
 
         if ($match['negated'] === '!') {
@@ -72,5 +74,16 @@ final class FilterFactory {
      */
     private static function getContentString(Item $item): string {
         return $item->getContent()->getRaw();
+    }
+
+    /**
+     * @param Item<mixed> $item
+     *
+     * @return string[]
+     */
+    private static function getAuthors(Item $item): array {
+        $author = $item->getAuthor();
+
+        return $author === null ? [] : [$author];
     }
 }

--- a/src/helpers/Filters/FilterSyntaxError.php
+++ b/src/helpers/Filters/FilterSyntaxError.php
@@ -1,0 +1,13 @@
+<?php
+
+// SPDX-FileCopyrightText: 2023 Jan Tojnar <jtojnar@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace helpers\Filters;
+
+use Exception;
+
+final class FilterSyntaxError extends Exception {
+}

--- a/src/helpers/Filters/MapFilter.php
+++ b/src/helpers/Filters/MapFilter.php
@@ -1,0 +1,41 @@
+<?php
+
+// SPDX-FileCopyrightText: 2023 Jan Tojnar <jtojnar@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace helpers\Filters;
+
+use spouts\Item;
+
+/**
+ * Filter that admits an item iff the inner filter admits an item obtained from the original item with the given transform function.
+ *
+ * @template T
+ * @template InnerT
+ * @implements Filter<T>
+ */
+final class MapFilter implements Filter {
+    /** @var Filter<InnerT> */
+    private $filter;
+
+    /** @var callable(T): InnerT */
+    private $transform;
+
+    /**
+     * @param Filter<InnerT> $filter
+     * @param callable(T): InnerT $transform
+     */
+    public function __construct(Filter $filter, callable $transform) {
+        $this->filter = $filter;
+        $this->transform = $transform;
+    }
+
+    /**
+     * @param T $item
+     */
+    public function admits($item): bool {
+        return $this->filter->admits(($this->transform)($item));
+    }
+}

--- a/src/helpers/Filters/NegationFilter.php
+++ b/src/helpers/Filters/NegationFilter.php
@@ -1,0 +1,35 @@
+<?php
+
+// SPDX-FileCopyrightText: 2023 Jan Tojnar <jtojnar@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace helpers\Filters;
+
+use spouts\Item;
+
+/**
+ * Filter that rejects an item iff inner filter admits it.
+ *
+ * @template T
+ * @implements Filter<T>
+ */
+final class NegationFilter implements Filter {
+    /** @var Filter<T> */
+    private $filter;
+
+    /**
+     * @param Filter<T> $filter
+     */
+    public function __construct(Filter $filter) {
+        $this->filter = $filter;
+    }
+
+    /**
+     * @param T $item
+     */
+    public function admits($item): bool {
+        return !$this->filter->admits($item);
+    }
+}

--- a/src/helpers/Filters/RegexFilter.php
+++ b/src/helpers/Filters/RegexFilter.php
@@ -1,0 +1,42 @@
+<?php
+
+// SPDX-FileCopyrightText: 2023 Jan Tojnar <jtojnar@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace helpers\Filters;
+
+use spouts\Item;
+
+/**
+ * Filter that admits an item iff the given regular expression matches it.
+ *
+ * @implements Filter<string>
+ */
+final class RegexFilter implements Filter {
+    /** @var string */
+    private $regex;
+
+    public function __construct(string $regex) {
+        if (@preg_match('/^\\/((?<!\\\\)(?:\\\\)*\\/|[^\\/])*\\/$/', $regex) === 0) {
+            throw new FilterSyntaxError("Invalid regex {$regex}, should start and end with a forward slash and not contain un-escaped forward slashes");
+        }
+
+        if (@preg_match($regex, '') === false) {
+            throw new FilterSyntaxError("Invalid regex {$regex}");
+        }
+
+        $this->regex = $regex;
+    }
+
+    /**
+     * @param string $item
+     */
+    public function admits($item): bool {
+        $result = @preg_match($this->regex, $item);
+        \assert($result !== false); // Verified at construction.
+
+        return $result === 1;
+    }
+}

--- a/tests/Helpers/FilterTest.php
+++ b/tests/Helpers/FilterTest.php
@@ -84,7 +84,7 @@ final class FilterTest extends TestCase {
     /**
      * @return Item<mixed>
      */
-    private static function mkItem(string $title, string $content): Item {
+    private static function mkItem(string $title, string $content, ?string $author = null): Item {
         return new Item(
             /* id: */ '0',
             /* title: */ HtmlString::fromRaw($title),
@@ -93,7 +93,7 @@ final class FilterTest extends TestCase {
             /* icon: */ null,
             /* link: */ '',
             /* date: */ new DateTimeImmutable(),
-            /* author: */ null,
+            /* author: */ $author,
             /* extraData: */ null
         );
     }
@@ -316,6 +316,64 @@ final class FilterTest extends TestCase {
                 /* content: */ 'Regular expressions are great.'
             ),
             false,
+        ];
+
+        yield 'Author: Match' => [
+            'author:/John/',
+            self::mkItem(
+                /* title: */ 'foo',
+                /* content: */ 'foo',
+                /* author: */ 'John'
+            ),
+            true,
+        ];
+
+        yield 'Author: No match' => [
+            'author:/John/',
+            self::mkItem(
+                /* title: */ 'John’s risotto recipe',
+                /* content: */ 'John recommends using rice.',
+                /* author: */ 'Josh'
+            ),
+            false,
+        ];
+
+        yield 'Author: No author' => [
+            'author:/John/',
+            self::mkItem(
+                /* title: */ 'John’s risotto recipe',
+                /* content: */ 'John recommends using rice.'
+            ),
+            false,
+        ];
+
+        yield 'Not(Author): Match' => [
+            '!author:/John/',
+            self::mkItem(
+                /* title: */ 'foo',
+                /* content: */ 'foo',
+                /* author: */ 'John'
+            ),
+            false,
+        ];
+
+        yield 'Not(Author): No match' => [
+            '!author:/John/',
+            self::mkItem(
+                /* title: */ 'John’s risotto recipe',
+                /* content: */ 'John recommends using rice.',
+                /* author: */ 'Josh'
+            ),
+            true,
+        ];
+
+        yield 'Not(Author): No author' => [
+            '!author:/John/',
+            self::mkItem(
+                /* title: */ 'John’s risotto recipe',
+                /* content: */ 'John recommends using rice.'
+            ),
+            true,
         ];
     }
 

--- a/tests/Helpers/FilterTest.php
+++ b/tests/Helpers/FilterTest.php
@@ -1,0 +1,151 @@
+<?php
+
+// SPDX-FileCopyrightText: 2023 Jan Tojnar <jtojnar@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace Tests\Helpers;
+
+use DateTimeImmutable;
+use helpers\Filters\Filter;
+use helpers\Filters\FilterFactory;
+use helpers\Filters\FilterSyntaxError;
+use helpers\Filters\MapFilter;
+use helpers\Filters\RegexFilter;
+use helpers\HtmlString;
+use PHPUnit\Framework\TestCase;
+use spouts\Item;
+
+final class FilterTest extends TestCase {
+    /**
+     * @return iterable<array{string}>
+     */
+    public function invalidRegexProvider(): iterable {
+        yield 'No slashes' => [
+            'pattern',
+        ];
+
+        yield 'Unescaped slash within' => [
+            '/pat/tern/',
+        ];
+
+        yield 'Modifiers' => [
+            '/pattern/i',
+        ];
+
+        yield 'Unsupported delimiters' => [
+            '(pattern)',
+        ];
+
+        yield 'Empty string' => [
+            '',
+        ];
+    }
+
+    /**
+     * @dataProvider invalidRegexProvider
+     */
+    public function testRegexError(string $regex): void {
+        $this->expectException(FilterSyntaxError::class);
+        new RegexFilter($regex);
+    }
+
+    /**
+     * @return iterable<array{string, class-string<Filter<mixed>>}>
+     */
+    public function validPatternProvider(): iterable {
+        yield 'Plain' => [
+            '/pattern/',
+            MapFilter::class,
+        ];
+
+        yield 'Escaped slash within' => [
+            '/pat\\/tern/',
+            MapFilter::class,
+        ];
+
+        yield 'Modifiers' => [
+            '/(?i)pattern/',
+            MapFilter::class,
+        ];
+    }
+
+    /**
+     * @param class-string<Filter<mixed>> $class
+     *
+     * @dataProvider validPatternProvider
+     */
+    public function testRegexOkay(string $expression, string $class): void {
+        $filter = FilterFactory::fromString($expression);
+        $this->assertInstanceOf($class, $filter);
+    }
+
+    /**
+     * @return Item<mixed>
+     */
+    private static function mkItem(string $title, string $content): Item {
+        return new Item(
+            /* id: */ '0',
+            /* title: */ HtmlString::fromRaw($title),
+            /* content: */ HtmlString::fromRaw($content),
+            /* thumbnail: */ null,
+            /* icon: */ null,
+            /* link: */ '',
+            /* date: */ new DateTimeImmutable(),
+            /* author: */ null,
+            /* extraData: */ null
+        );
+    }
+
+    /**
+     * @return iterable<array{string, Item<mixed>, bool}>
+     */
+    public function admittanceProvider(): iterable {
+        yield 'Item: No match' => [
+            '/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'foo',
+                /* content: */ 'foo'
+            ),
+            false,
+        ];
+
+        yield 'Item: Title match' => [
+            '/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'Regexp tips and tricks',
+                /* content: */ 'foo'
+            ),
+            true,
+        ];
+
+        yield 'Item: Content match' => [
+            '/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'foo',
+                /* content: */ 'Regular expressions are great.'
+            ),
+            true,
+        ];
+
+        yield 'Item: Both match' => [
+            '/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'Regexp tips and tricks',
+                /* content: */ 'Regular expressions are great.'
+            ),
+            true,
+        ];
+    }
+
+    /**
+     * @param Item<mixed> $item
+     *
+     * @dataProvider admittanceProvider
+     */
+    public function testAdmittance(string $expression, Item $item, bool $admitted): void {
+        $filter = FilterFactory::fromString($expression);
+        $this->assertSame($admitted, $filter->admits($item));
+    }
+}

--- a/tests/Helpers/FilterTest.php
+++ b/tests/Helpers/FilterTest.php
@@ -137,6 +137,78 @@ final class FilterTest extends TestCase {
             ),
             true,
         ];
+
+        yield 'Title: No match' => [
+            'title:/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'foo',
+                /* content: */ 'foo'
+            ),
+            false,
+        ];
+
+        yield 'Title: Title match' => [
+            'title:/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'Regexp tips and tricks',
+                /* content: */ 'foo'
+            ),
+            true,
+        ];
+
+        yield 'Title: Content match' => [
+            'title:/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'foo',
+                /* content: */ 'Regular expressions are great.'
+            ),
+            false,
+        ];
+
+        yield 'Title: Both match' => [
+            'title:/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'Regexp tips and tricks',
+                /* content: */ 'Regular expressions are great.'
+            ),
+            true,
+        ];
+
+        yield 'Content: No match' => [
+            'content:/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'foo',
+                /* content: */ 'foo'
+            ),
+            false,
+        ];
+
+        yield 'Content: Title match' => [
+            'content:/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'Regexp tips and tricks',
+                /* content: */ 'foo'
+            ),
+            false,
+        ];
+
+        yield 'Content: Content match' => [
+            'content:/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'foo',
+                /* content: */ 'Regular expressions are great.'
+            ),
+            true,
+        ];
+
+        yield 'Content: Both match' => [
+            'content:/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'Regexp tips and tricks',
+                /* content: */ 'Regular expressions are great.'
+            ),
+            true,
+        ];
     }
 
     /**

--- a/tests/Helpers/FilterTest.php
+++ b/tests/Helpers/FilterTest.php
@@ -138,6 +138,42 @@ final class FilterTest extends TestCase {
             true,
         ];
 
+        yield 'Not(Item): No match' => [
+            '!/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'foo',
+                /* content: */ 'foo'
+            ),
+            true,
+        ];
+
+        yield 'Not(Item): Title match' => [
+            '!/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'Regexp tips and tricks',
+                /* content: */ 'foo'
+            ),
+            false,
+        ];
+
+        yield 'Not(Item): Content match' => [
+            '!/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'foo',
+                /* content: */ 'Regular expressions are great.'
+            ),
+            false,
+        ];
+
+        yield 'Not(Item): Both match' => [
+            '!/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'Regexp tips and tricks',
+                /* content: */ 'Regular expressions are great.'
+            ),
+            false,
+        ];
+
         yield 'Title: No match' => [
             'title:/(?i)reg(ular expression|exp)/',
             self::mkItem(
@@ -174,6 +210,42 @@ final class FilterTest extends TestCase {
             true,
         ];
 
+        yield 'Not(Title): No match' => [
+            '!title:/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'foo',
+                /* content: */ 'foo'
+            ),
+            true,
+        ];
+
+        yield 'Not(Title): Title match' => [
+            '!title:/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'Regexp tips and tricks',
+                /* content: */ 'foo'
+            ),
+            false,
+        ];
+
+        yield 'Not(Title): Content match' => [
+            '!title:/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'foo',
+                /* content: */ 'Regular expressions are great.'
+            ),
+            true,
+        ];
+
+        yield 'Not(Title): Both match' => [
+            '!title:/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'Regexp tips and tricks',
+                /* content: */ 'Regular expressions are great.'
+            ),
+            false,
+        ];
+
         yield 'Content: No match' => [
             'content:/(?i)reg(ular expression|exp)/',
             self::mkItem(
@@ -208,6 +280,42 @@ final class FilterTest extends TestCase {
                 /* content: */ 'Regular expressions are great.'
             ),
             true,
+        ];
+
+        yield 'Not(Content): No match' => [
+            '!content:/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'foo',
+                /* content: */ 'foo'
+            ),
+            true,
+        ];
+
+        yield 'Not(Content): Title match' => [
+            '!content:/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'Regexp tips and tricks',
+                /* content: */ 'foo'
+            ),
+            true,
+        ];
+
+        yield 'Not(Content): Content match' => [
+            '!content:/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'foo',
+                /* content: */ 'Regular expressions are great.'
+            ),
+            false,
+        ];
+
+        yield 'Not(Content): Both match' => [
+            '!content:/(?i)reg(ular expression|exp)/',
+            self::mkItem(
+                /* title: */ 'Regexp tips and tricks',
+                /* content: */ 'Regular expressions are great.'
+            ),
+            false,
         ];
     }
 


### PR DESCRIPTION
The filter expression can take one of the following forms:

1. An *atomic filter*: a Perl-compatible regular expression, as [accepted by PHP](https://www.php.net/manual/en/reference.pcre.pattern.syntax.php), between forward slashes (`/`). For example, `/reg(ular expression|ex)/` will keep only items whose title or content matches the regular expression between the slashes (i.e. contain the phrase “regular expression” or “regex”). Learn more about regular expressions on <https://www.regular-expressions.info/>.
2. A *field-specific filter*: an *atomic filter* preceded by one of the field names below and a colon:
    - `title:/regex/` will keep only items whose title matches the regular expression between the slashes.
    - `content:/regex/` will keep only items whose content matches the regular expression between the slashes.
    - `author:/regex/` will keep only items which have an author that matches the regular expression between the slashes.
    - `category:/regex/` will keep only items which have a category that matches the regular expression between the slashes.
3. A *negated filter* is either an *atomic filter* or a *field-specific filter* preceded by an exclamation mark (`!`). It will only keep items would not be kept by the filter after the exclamation mark.
