### PR TITLE
Support url filters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 - YouTube spout now includes the video description. ([#1412](https://github.com/fossar/selfoss/pull/1412))
 - Mastodon share button was added. Can be enabled by adding `m` to `share` and setting `mastodon` pointing to your chosen instance. ([#1421](https://github.com/fossar/selfoss/pull/1421))
 - Source filters can be negated, or limited to only title or only content. ([#1423](https://github.com/fossar/selfoss/pull/1423))
-- Sources can be filtered based on item’s author or categories. ([#1423](https://github.com/fossar/selfoss/pull/1423))
+- Sources can be filtered based on item’s author, URL or categories. ([#1423](https://github.com/fossar/selfoss/pull/1423), [#1424](https://github.com/fossar/selfoss/pull/1424))
 - Source filter expression is now validated whenever a source is modified. ([#1423](https://github.com/fossar/selfoss/pull/1423))
 
 ### Bug fixes

--- a/docs/content/docs/usage/filters.md
+++ b/docs/content/docs/usage/filters.md
@@ -11,6 +11,7 @@ The filter expression can take one of the following forms:
 2. A *field-specific filter*: an *atomic filter* preceded by one of the field names below and a colon:
     - `title:/regex/` will keep only items whose title matches the regular expression between the slashes.
     - `content:/regex/` will keep only items whose content matches the regular expression between the slashes.
+    - `url:/regex/` will keep only items whose URL matches the regular expression between the slashes. For example, `url:/^https:\/\/www\.bbc\.co\.uk\/sport\//` will match all articles in sport section of BBC news.
     - `author:/regex/` will keep only items which have an author that matches the regular expression between the slashes.
     - `category:/regex/` will keep only items which have a category that matches the regular expression between the slashes.
 3. A *negated filter* is either an *atomic filter* or a *field-specific filter* preceded by an exclamation mark (`!`). It will only keep items would not be kept by the filter after the exclamation mark.

--- a/src/helpers/Filters/FilterFactory.php
+++ b/src/helpers/Filters/FilterFactory.php
@@ -37,12 +37,14 @@ final class FilterFactory {
             $filter = new MapFilter($filter, Closure::fromCallable([self::class, 'getTitleString']));
         } elseif ($field === 'content') {
             $filter = new MapFilter($filter, Closure::fromCallable([self::class, 'getContentString']));
+        } elseif ($field === 'url') {
+            $filter = new MapFilter($filter, Closure::fromCallable([self::class, 'getUrl']));
         } elseif ($field === 'author') {
             $filter = new MapFilter(new DisjunctionFilter($filter), Closure::fromCallable([self::class, 'getAuthors']));
         } elseif ($field === 'category') {
             $filter = new MapFilter(new DisjunctionFilter($filter), Closure::fromCallable([self::class, 'getCategories']));
         } else {
-            throw new FilterSyntaxError("Invalid filter expression {$expression}, field must be one of “title”, “content”, “author” or “category”.");
+            throw new FilterSyntaxError("Invalid filter expression {$expression}, field must be one of “title”, “content”, “url”, “author” or “category”.");
         }
 
         if ($match['negated'] === '!') {
@@ -76,6 +78,13 @@ final class FilterFactory {
      */
     private static function getContentString(Item $item): string {
         return $item->getContent()->getRaw();
+    }
+
+    /**
+     * @param Item<mixed> $item
+     */
+    private static function getUrl(Item $item): string {
+        return $item->getLink();
     }
 
     /**

--- a/tests/Helpers/FilterTest.php
+++ b/tests/Helpers/FilterTest.php
@@ -82,13 +82,9 @@ final class FilterTest extends TestCase {
     }
 
     /**
-     * @template T
-     *
-     * @param T $extraData
-     *
-     * @return Item<T>
+     * @return Item<null>
      */
-    private static function mkItem(string $title, string $content, ?string $author = null, $extraData = null): Item {
+    private static function mkItem(string $title, string $content): Item {
         return new Item(
             /* id: */ '0',
             /* title: */ HtmlString::fromRaw($title),
@@ -97,8 +93,8 @@ final class FilterTest extends TestCase {
             /* icon: */ null,
             /* link: */ '',
             /* date: */ new DateTimeImmutable(),
-            /* author: */ $author,
-            /* extraData: */ $extraData
+            /* author: */ null,
+            /* extraData: */ null
         );
     }
 
@@ -326,9 +322,8 @@ final class FilterTest extends TestCase {
             'author:/John/',
             self::mkItem(
                 /* title: */ 'foo',
-                /* content: */ 'foo',
-                /* author: */ 'John'
-            ),
+                /* content: */ 'foo'
+            )->withAuthor('John'),
             true,
         ];
 
@@ -336,9 +331,8 @@ final class FilterTest extends TestCase {
             'author:/John/',
             self::mkItem(
                 /* title: */ 'John’s risotto recipe',
-                /* content: */ 'John recommends using rice.',
-                /* author: */ 'Josh'
-            ),
+                /* content: */ 'John recommends using rice.'
+            )->withAuthor('Josh'),
             false,
         ];
 
@@ -355,9 +349,8 @@ final class FilterTest extends TestCase {
             '!author:/John/',
             self::mkItem(
                 /* title: */ 'foo',
-                /* content: */ 'foo',
-                /* author: */ 'John'
-            ),
+                /* content: */ 'foo'
+            )->withAuthor('John'),
             false,
         ];
 
@@ -365,9 +358,8 @@ final class FilterTest extends TestCase {
             '!author:/John/',
             self::mkItem(
                 /* title: */ 'John’s risotto recipe',
-                /* content: */ 'John recommends using rice.',
-                /* author: */ 'Josh'
-            ),
+                /* content: */ 'John recommends using rice.'
+            )->withAuthor('Josh'),
             true,
         ];
 
@@ -397,10 +389,8 @@ final class FilterTest extends TestCase {
             'category:/sport/',
             self::mkItem(
                 /* title: */ 'Real Milan wins kickball terran bowl',
-                /* content: */ '',
-                /* author: */ null,
-                /* extraData: */ $stubItemSport
-            ),
+                /* content: */ ''
+            )->withExtraData($stubItemSport),
             true,
         ];
 
@@ -408,10 +398,8 @@ final class FilterTest extends TestCase {
             'category:/sport/',
             self::mkItem(
                 /* title: */ 'Arrest warrant issued for Putin over war crime allegations',
-                /* content: */ '',
-                /* author: */ null,
-                /* extraData: */ $stubItemActualNews
-            ),
+                /* content: */ ''
+            )->withExtraData($stubItemActualNews),
             false,
         ];
 
@@ -419,10 +407,8 @@ final class FilterTest extends TestCase {
             'category:/sport/',
             self::mkItem(
                 /* title: */ 'Real Milan wins kickball terran bowl',
-                /* content: */ '',
-                /* author: */ null,
-                /* extraData: */ $stubItemNoCategories
-            ),
+                /* content: */ ''
+            )->withExtraData($stubItemNoCategories),
             false,
         ];
 
@@ -439,10 +425,8 @@ final class FilterTest extends TestCase {
             '!category:/sport/',
             self::mkItem(
                 /* title: */ 'Real Milan wins kickball terran bowl',
-                /* content: */ '',
-                /* author: */ null,
-                /* extraData: */ $stubItemSport
-            ),
+                /* content: */ ''
+            )->withExtraData($stubItemSport),
             false,
         ];
 
@@ -450,10 +434,8 @@ final class FilterTest extends TestCase {
             '!category:/sport/',
             self::mkItem(
                 /* title: */ 'Arrest warrant issued for Putin over war crime allegations',
-                /* content: */ '',
-                /* author: */ null,
-                /* extraData: */ $stubItemActualNews
-            ),
+                /* content: */ ''
+            )->withExtraData($stubItemActualNews),
             true,
         ];
 
@@ -461,10 +443,8 @@ final class FilterTest extends TestCase {
             '!category:/sport/',
             self::mkItem(
                 /* title: */ 'Foo',
-                /* content: */ '',
-                /* author: */ null,
-                /* extraData: */ $stubItemNoCategories
-            ),
+                /* content: */ ''
+            )->withExtraData($stubItemNoCategories),
             true,
         ];
 

--- a/tests/Helpers/FilterTest.php
+++ b/tests/Helpers/FilterTest.php
@@ -318,6 +318,42 @@ final class FilterTest extends TestCase {
             false,
         ];
 
+        yield 'Url: Match' => [
+            'url:/^https:\\/\\/www\\.bbc\\.co\\.uk\\/sport\\//',
+            self::mkItem(
+                /* title: */ 'Fabio Paratici: Tottenham managing director banned worldwide by Fifa',
+                /* content: */ ''
+            )->withLink('https://www.bbc.co.uk/sport/football/65112730'),
+            true,
+        ];
+
+        yield 'Url: No match' => [
+            'url:/^https:\\/\\/www\\.bbc\\.co\\.uk\\/sport\\//',
+            self::mkItem(
+                /* title: */ 'Arrest warrant issued for Putin over war crime allegations',
+                /* content: */ ''
+            )->withLink('https://www.bbc.co.uk/news/world-europe-64992727'),
+            false,
+        ];
+
+        yield 'Not(Url): Match' => [
+            '!url:/^https:\\/\\/www\\.bbc\\.co\\.uk\\/sport\\//',
+            self::mkItem(
+                /* title: */ 'Fabio Paratici: Tottenham managing director banned worldwide by Fifa',
+                /* content: */ ''
+            )->withLink('https://www.bbc.co.uk/sport/football/65112730'),
+            false,
+        ];
+
+        yield 'Not(Url): No match' => [
+            '!url:/^https:\\/\\/www\\.bbc\\.co\\.uk\\/sport\\//',
+            self::mkItem(
+                /* title: */ 'Arrest warrant issued for Putin over war crime allegations',
+                /* content: */ ''
+            )->withLink('https://www.bbc.co.uk/news/world-europe-64992727'),
+            true,
+        ];
+
         yield 'Author: Match' => [
             'author:/John/',
             self::mkItem(


### PR DESCRIPTION
Follow up to #1423.

This is useful for e.g. removing articles that have categories in the URL instead of in the feed, like BBC has.
One can, for example, ignore sport news with `!url:/^https:\/\/www\.bbc\.co\.uk\/sport\//` as the filter.