### PR TITLE
Update: Support sending update status after each source

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 - Re-added “Next” button on smartphones. ([#1406](https://github.com/fossar/selfoss/issues/1406)
 - Fix compressed SVG (svgz) support. ([#1418](https://github.com/fossar/selfoss/pulls/1418)
 - Fix article links containing HTML-special characters. ([#1407](https://github.com/fossar/selfoss/issues/1407))
+- Reduce the chance of “Update all sources” button timing out. ([#1428](https://github.com/fossar/selfoss/pulls/1428))
 
 ### Customization changes
 - Custom spouts must explicitly pass `null` to `Item::__construct()` when they do not need the `extraData` argument. ([#1415](https://github.com/fossar/selfoss/pull/1415))

--- a/assets/js/requests/sources.js
+++ b/assets/js/requests/sources.js
@@ -29,7 +29,10 @@ export function refreshSingle(id) {
  */
 export function refreshAll() {
     return ajax.get('update', {
-        timeout: 0
+        headers: {
+            'Accept': 'text/event-stream',
+        },
+        timeout: 0,
     }).promise;
 }
 

--- a/cliupdate.php
+++ b/cliupdate.php
@@ -5,6 +5,18 @@ declare(strict_types=1);
 chdir(__DIR__);
 require __DIR__ . '/src/common.php';
 
+use helpers\UpdateVisitor;
+
 /** @var Dice\Dice $dice */
 $loader = $dice->create(helpers\ContentLoader::class);
-$loader->update();
+$updateVisitor = new class() implements UpdateVisitor {
+    public function started(int $count): void {
+    }
+
+    public function sourceUpdated(): void {
+    }
+
+    public function finished(): void {
+    }
+};
+$loader->update($updateVisitor);

--- a/docs/api-description.json
+++ b/docs/api-description.json
@@ -3,7 +3,7 @@
   "servers": [],
   "info": {
     "description": "You can access selfoss by using the same backend as selfoss user interface: The RESTful HTTP JSON API. There are a few urls where you can get information from selfoss and some for updating data. Assume you want all tags for rendering this in your own app. You have to make an HTTP GET call on the url /tags:\n\n```\nGET http://yourselfossurl.com/tags\n```\nThe result is following JSON formatted response (in this example two tags “blog” and “deviantart” are available:\n\n```\n[{\"tag\":\"blog\",\"color\":\"#251f10\",\"unread\":\"1\"},\n{\"tag\":\"deviantart\",\"color\":\"#e78e5c\",\"unread\":\"0\"}]\n```\n\nFollowing docs shows you which calls are possible and which response you can expect.",
-    "version": "6.0.1",
+    "version": "6.1.0",
     "title": "selfoss"
   },
   "tags": [

--- a/src/constants.php
+++ b/src/constants.php
@@ -9,4 +9,4 @@ const SELFOSS_VERSION = '2.20-SNAPSHOT';
 // independent of selfoss version
 // needs to be bumped each time public API is changed (follows semver)
 // keep in sync with docs/api-description.json
-const SELFOSS_API_VERSION = '6.0.1';
+const SELFOSS_API_VERSION = '6.1.0';

--- a/src/daos/Sources.php
+++ b/src/daos/Sources.php
@@ -52,6 +52,10 @@ class Sources implements SourcesInterface {
         $this->backend->saveLastUpdate($id, $lastEntry);
     }
 
+    public function count(): int {
+        return $this->backend->count();
+    }
+
     public function getByLastUpdate(): array {
         return $this->backend->getByLastUpdate();
     }

--- a/src/daos/SourcesInterface.php
+++ b/src/daos/SourcesInterface.php
@@ -52,6 +52,11 @@ interface SourcesInterface {
     public function saveLastUpdate(int $id, ?int $lastEntry): void;
 
     /**
+     * Gets the number of sources.
+     */
+    public function count(): int;
+
+    /**
      * returns all sources
      *
      * @return array<array{id: int, title: string, tags: string, spout: string, params: string, filter: ?string, error: ?string, lastupdate: ?int, lastentry: ?int}> all sources

--- a/src/daos/mysql/Sources.php
+++ b/src/daos/mysql/Sources.php
@@ -142,6 +142,15 @@ class Sources implements \daos\SourcesInterface {
     }
 
     /**
+     * Gets the number of sources.
+     */
+    public function count(): int {
+        $ret = $this->database->exec('SELECT COUNT(*) AS amount FROM ' . $this->configuration->dbPrefix . 'sources');
+
+        return (int) $ret[0]['amount'];
+    }
+
+    /**
      * returns all sources
      *
      * @return array<array{id: int, title: string, tags: string, spout: string, params: string, filter: ?string, error: ?string, lastupdate: ?int, lastentry: ?int}> all sources

--- a/src/helpers/ContentLoader.php
+++ b/src/helpers/ContentLoader.php
@@ -47,11 +47,17 @@ class ContentLoader {
     /**
      * updates all sources
      */
-    public function update(): void {
-        foreach ($this->sourcesDao->getByLastUpdate() as $source) {
+    public function update(UpdateVisitor $updateVisitor): void {
+        $count = $this->sourcesDao->count();
+        $updateVisitor->started($count);
+
+        $sources = $this->sourcesDao->getByLastUpdate();
+        foreach ($sources as $source) {
             $this->fetch($source);
+            $updateVisitor->sourceUpdated();
         }
         $this->cleanup();
+        $updateVisitor->finished();
     }
 
     /**

--- a/src/helpers/UpdateVisitor.php
+++ b/src/helpers/UpdateVisitor.php
@@ -1,0 +1,16 @@
+<?php
+
+// SPDX-FileCopyrightText: 2016–2023 Jan Tojnar <jtojnar@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace helpers;
+
+interface UpdateVisitor {
+    public function started(int $count): void;
+
+    public function sourceUpdated(): void;
+
+    public function finished(): void;
+}


### PR DESCRIPTION
This will reduce the chance that the web server will time out due to no response being sent. In the future, we will be able to use the data for displaying a progress bar in the client.

Even though the `GET /update` endpoint is not actually part of the public API, we increase the API version to 6.0.1 → 6.1.0, and only use the new output when `Accept: text/event-stream` header is sent with the request, in order to preserve backwards compatibility.

This is using Server-sent events-style response with three event types:

- `started`, with `count` data field containing the number of sources that will be updated
- `sourceUpdated`, with `finishedCount` data field containing the number of sources that will have been updated so far
- `finished`

https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events

cc @davidoskky @aminecmi This might be useful for RfS as well.