### PR TITLE
client: Fix log-in loop

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 - Fix compressed SVG (svgz) support. ([#1418](https://github.com/fossar/selfoss/pulls/1418)
 - Fix article links containing HTML-special characters. ([#1407](https://github.com/fossar/selfoss/issues/1407))
 - Reduce the chance of “Update all sources” button timing out. ([#1428](https://github.com/fossar/selfoss/pulls/1428))
+- Fix a log-in loop in client. ([#1429](https://github.com/fossar/selfoss/pulls/1429))
 
 ### Customization changes
 - Custom spouts must explicitly pass `null` to `Item::__construct()` when they do not need the `extraData` argument. ([#1415](https://github.com/fossar/selfoss/pull/1415))

--- a/assets/js/helpers/authorizations.js
+++ b/assets/js/helpers/authorizations.js
@@ -1,4 +1,5 @@
 import { useListenableValue } from './hooks';
+import { useMemo } from 'react';
 
 
 export function useLoggedIn() {
@@ -6,13 +7,28 @@ export function useLoggedIn() {
 }
 
 export function useAllowedToRead() {
-    return selfoss.isAllowedToRead();
+    const loggedIn = useLoggedIn();
+
+    return useMemo(
+        () => selfoss.isAllowedToRead(),
+        [loggedIn],
+    );
 }
 
 export function useAllowedToUpdate() {
-    return selfoss.isAllowedToUpdate();
+    const loggedIn = useLoggedIn();
+
+    return useMemo(
+        () => selfoss.isAllowedToUpdate(),
+        [loggedIn],
+    );
 }
 
 export function useAllowedToWrite() {
-    return selfoss.isAllowedToWrite();
+    const loggedIn = useLoggedIn();
+
+    return useMemo(
+        () => selfoss.isAllowedToWrite(),
+        [loggedIn],
+    );
 }

--- a/assets/js/templates/App.jsx
+++ b/assets/js/templates/App.jsx
@@ -23,6 +23,7 @@ import Navigation from './Navigation';
 import SearchList from './SearchList';
 import makeShortcuts from '../shortcuts';
 import * as icons from '../icons';
+import { useAllowedToRead, useAllowedToWrite } from '../helpers/authorizations';
 import { ConfigurationContext } from '../helpers/configuration';
 import { useIsSmartphone, useListenableValue } from '../helpers/hooks';
 import { ENTRIES_ROUTE_PATTERN } from '../helpers/uri';
@@ -189,6 +190,9 @@ function PureApp({
 
     const _ = React.useContext(LocalizationContext);
 
+    const isAllowedToRead = useAllowedToRead();
+    const isAllowedToWrite = useAllowedToWrite();
+
     return (
         <React.StrictMode>
             <Message message={globalMessage} />
@@ -205,7 +209,7 @@ function PureApp({
 
                 <Route path="/password">
                     <CheckAuthorization
-                        isAllowed={selfoss.isAllowedToWrite()}
+                        isAllowed={isAllowedToWrite}
                         returnLocation="/password"
                         _={_}
                     >
@@ -219,7 +223,7 @@ function PureApp({
 
                 <Route path="/">
                     <CheckAuthorization
-                        isAllowed={selfoss.isAllowedToRead()}
+                        isAllowed={isAllowedToRead}
                         _={_}
                     >
                         <div id="nav-mobile" role="navigation">


### PR DESCRIPTION
With `public=0`, when user logs in, sometimes the logged in state would not reflect to the `CheckAuthorization` component, so the entries page wrapped in `CheckAuthorization` would redirect user back to log-in page.
