### PR TITLE
Update: Ensure that progress reports are sent ASAP

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,7 +18,7 @@
 - Re-added “Next” button on smartphones. ([#1406](https://github.com/fossar/selfoss/issues/1406)
 - Fix compressed SVG (svgz) support. ([#1418](https://github.com/fossar/selfoss/pulls/1418)
 - Fix article links containing HTML-special characters. ([#1407](https://github.com/fossar/selfoss/issues/1407))
-- Reduce the chance of “Update all sources” button timing out. ([#1428](https://github.com/fossar/selfoss/pulls/1428))
+- Reduce the chance of “Update all sources” button timing out. ([#1428](https://github.com/fossar/selfoss/pulls/1428), [#1430](https://github.com/fossar/selfoss/pulls/1430))
 - Fix a log-in loop in client. ([#1429](https://github.com/fossar/selfoss/pulls/1429))
 - Fix errors in Firefox’s private browsing mode.
 

--- a/assets/js/requests/sources.js
+++ b/assets/js/requests/sources.js
@@ -33,7 +33,7 @@ export function refreshAll() {
             'Accept': 'text/event-stream',
         },
         timeout: 0,
-    }).promise;
+    }).promise.then(response => response.text());
 }
 
 /**


### PR DESCRIPTION
Follow-up to 9741e39d1fa4070d4d42e774c8c088da055eaa7b.

Various layers in the network stack including php-fpm, Apache’s `mod_proxy_fcgi` and Nginx’s `ngx_http_fastcgi_module` will buffer responses.
Since the individual events are short compared to buffer sizes, it may happen that PHP keeps holding onto the output, waiting for the response buffer to fill up, and, in the meanwhile, nginx will time out waiting for the contents.
Let’s prevent that by ending all output buffering we can on PHP side.
(There would be ¿up to two? levels: one for `output_buffering`, one for `zlib.output_compression`.)

Web server buffering is not that critical (unless there is another layer like a proxy) but it is useful to disable it as well so that progress updates are reflected live. We will do that for nginx, where it can be done simply with a response header (unless disabled in nginx configuration).

Since the response will now start arriving immediately, we need to modify the client so that the promise returned by `refreshAll` is only fulfilled once the whole body arrives. Otherwise, the refresh icon would stop spinning just after receiving the headers.