### PR TITLE
wip: Add advanced source settings

### DIFF
--- a/client/js/templates/Source.jsx
+++ b/client/js/templates/Source.jsx
@@ -317,6 +317,11 @@ function SourceEditForm({
         [updateEditedSource]
     );
 
+    const iconOnChange = useCallback(
+        (event) => updateEditedSource({ icon: event.target.value }),
+        [updateEditedSource]
+    );
+
     const spoutOnChange = useCallback(
         (event) =>
             handleSpoutChange({
@@ -372,14 +377,18 @@ function SourceEditForm({
 
     const [showAdvanced, setShowAdvanced] = useState(false);
     const [filterUsed, setFilterUsed] = useState(source.filter !== '');
+    // TODO: Remove undefined check once we implement it server side.
+    const [iconUsed, setIconUsed] = useState(source.icon !== '' && source.icon !== undefined);
 
     const toggleShowAdvanced = useCallback(
         () => {
             setShowAdvanced((advanced) => !advanced);
             console.log(source.filter);
             setFilterUsed(source.filter !== '');
+            // TODO: Remove undefined check once we implement it server side.
+            setIconUsed(source.icon !== '' && source.icon !== undefined);
         },
-        [source.filter]
+        [source.filter, source.icon]
     );
 
     const sourceParamsContent = (
@@ -510,6 +519,26 @@ function SourceEditForm({
                         <span className="error">{sourceErrors['spout']}</span>
                     ) : null}
                 </li>
+
+                {showAdvanced || iconUsed ? (
+                    <li>
+                        <label htmlFor={`icon-${sourceId}`}>
+                            {/*_('source_icon')*/}
+                            {'Icon:'}
+                        </label>
+                        <input
+                            id={`icon-${sourceId}`}
+                            type="text"
+                            name="icon"
+                            accessKey="f"
+                            value={source.icon ?? ''}
+                            onChange={iconOnChange}
+                        />
+                        {sourceErrors['icon'] ? (
+                            <span className="error">{sourceErrors['icon']}</span>
+                        ) : null}
+                    </li>
+                ) : null}
 
                 {/* settings */}
                 {sourceParamsContent ? (

--- a/client/js/templates/Source.jsx
+++ b/client/js/templates/Source.jsx
@@ -370,6 +370,18 @@ function SourceEditForm({
 
     const _ = useContext(LocalizationContext);
 
+    const [showAdvanced, setShowAdvanced] = useState(false);
+    const [filterUsed, setFilterUsed] = useState(source.filter !== '');
+
+    const toggleShowAdvanced = useCallback(
+        () => {
+            setShowAdvanced((advanced) => !advanced);
+            console.log(source.filter);
+            setFilterUsed(source.filter !== '');
+        },
+        [source.filter]
+    );
+
     const sourceParamsContent = (
         sourceParamsLoading ? (
             <Spinner size="3x" label={_('source_params_loading')} />
@@ -451,22 +463,24 @@ function SourceEditForm({
                 </li>
 
                 {/* filter */}
-                <li>
-                    <label htmlFor={`filter-${sourceId}`}>
-                        {_('source_filter')}
-                    </label>
-                    <input
-                        id={`filter-${sourceId}`}
-                        type="text"
-                        name="filter"
-                        accessKey="f"
-                        value={source.filter ?? ''}
-                        onChange={filterOnChange}
-                    />
-                    {sourceErrors['filter'] ? (
-                        <span className="error">{sourceErrors['filter']}</span>
-                    ) : null}
-                </li>
+                {showAdvanced || filterUsed ? (
+                    <li>
+                        <label htmlFor={`filter-${sourceId}`}>
+                            {_('source_filter')}
+                        </label>
+                        <input
+                            id={`filter-${sourceId}`}
+                            type="text"
+                            name="filter"
+                            accessKey="f"
+                            value={source.filter ?? ''}
+                            onChange={filterOnChange}
+                        />
+                        {sourceErrors['filter'] ? (
+                            <span className="error">{sourceErrors['filter']}</span>
+                        ) : null}
+                    </li>
+                ) : null}
 
                 {/* type */}
                 <li>
@@ -513,6 +527,16 @@ function SourceEditForm({
 
                 {/* save/delete */}
                 <li className="source-action">
+                    <button
+                        type="button"
+                        className="source-toggle-advanced source-save"
+                        accessKey="a"
+                        onClick={toggleShowAdvanced}
+                    >
+                        {(showAdvanced ? 'Hide advanced' : 'Show advanced')}
+                        {/*{_(showAdvanced ? 'source_hide_advanced' : 'source_show_advanced')}*/}
+                    </button>
+                    {' • '}
                     <button
                         type="submit"
                         className="source-save"


### PR DESCRIPTION
Most people will not use filter for most sources so let’s introduce advanced settings and only show filter when filled in or when advanced settings are enabled.

This will allow us to implement less common features like [archival](https://github.com/fossar/selfoss/issues/1323), [reduced update frequency](https://github.com/fossar/selfoss/issues/1419) or [icon overriding](https://github.com/fossar/selfoss/issues/1448).

WIP because I do not like the the toggle button placement.

Also introduce “Icon override” proof of concept (only client side for now). At minimum we will want to allow URL entry but upload would be even better.
