### PR TITLE
config: Fix Wallabag version type

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@
 - Fix errors in Firefox’s private browsing mode.
 - Fix exporting OPML when there are tags that look like numbers ([#1439](https://github.com/fossar/selfoss/pull/1439))
 - Fix incorrect handling of tags in MySQL backend, which could result in OPML export being broken ([#1439](https://github.com/fossar/selfoss/pull/1439))
+- Fix sharing to Wallabag 2. ([#1465](https://github.com/fossar/selfoss/pull/1465))
 
 ### Customization changes
 - Custom spouts must explicitly pass `null` to `Item::__construct()` when they do not need the `extraData` argument. ([#1415](https://github.com/fossar/selfoss/pull/1415))

--- a/docs/api-description.json
+++ b/docs/api-description.json
@@ -3,7 +3,7 @@
   "servers": [],
   "info": {
     "description": "You can access selfoss by using the same backend as selfoss user interface: The RESTful HTTP JSON API. There are a few urls where you can get information from selfoss and some for updating data. Assume you want all tags for rendering this in your own app. You have to make an HTTP GET call on the url /tags:\n\n```\nGET http://yourselfossurl.com/tags\n```\nThe result is following JSON formatted response (in this example two tags “blog” and “deviantart” are available:\n\n```\n[{\"tag\":\"blog\",\"color\":\"#251f10\",\"unread\":\"1\"},\n{\"tag\":\"deviantart\",\"color\":\"#e78e5c\",\"unread\":\"0\"}]\n```\n\nFollowing docs shows you which calls are possible and which response you can expect.",
-    "version": "6.1.0",
+    "version": "7.0.0",
     "title": "selfoss"
   },
   "tags": [

--- a/src/constants.php
+++ b/src/constants.php
@@ -9,4 +9,4 @@ const SELFOSS_VERSION = '2.20-SNAPSHOT';
 // independent of selfoss version
 // needs to be bumped each time public API is changed (follows semver)
 // keep in sync with docs/api-description.json
-const SELFOSS_API_VERSION = '6.1.0';
+const SELFOSS_API_VERSION = '7.0.0';

--- a/src/helpers/Configuration.php
+++ b/src/helpers/Configuration.php
@@ -124,7 +124,7 @@ class Configuration {
 
     public string $wallabag = '';
 
-    public string $wallabagVersion = '2';
+    public int $wallabagVersion = 2;
 
     public ?string $wordpress = null;
 


### PR DESCRIPTION
The frontend compared the Wallabag version with a number using strict comparison since 16f1cd6a52ee6dffac61d82a7fdd368c8b4ecd68.
But when we switched to a custom configuration container in 1f194f8ca5edcc8f353f1d0d131ccb2ccd1ad087 (part to 2.19),
we accidentally made the version a string breaking sharing to Wallabag.

Bumping the API version since changes the type of field in `/api/about` endpoint, even though the fields are explicitly not part of the API promise.
