### PR TITLE
client: Mark entry as read when opening external link

### DIFF
--- a/client/js/templates/Item.jsx
+++ b/client/js/templates/Item.jsx
@@ -257,6 +257,8 @@ export default function Item({ currentTime, item, selected, expanded, setNavExpa
         [currentTime, item.datetime]
     );
 
+    const canWrite = useAllowedToWrite();
+
     const previouslyExpanded = usePreviousImmediate(expanded);
     const configuration = useContext(ConfigurationContext);
 
@@ -410,8 +412,6 @@ export default function Item({ currentTime, item, selected, expanded, setNavExpa
         }),
         [item.source]
     );
-
-    const canWrite = useAllowedToWrite();
 
     const _ = useContext(LocalizationContext);
 

--- a/client/js/templates/Item.jsx
+++ b/client/js/templates/Item.jsx
@@ -46,10 +46,6 @@ function setupLightbox({
     }));
 }
 
-function stopPropagation(event) {
-    event.stopPropagation();
-}
-
 function lazyLoadImages(content) {
     content.querySelectorAll('img').forEach((img) => {
         img.setAttribute('src', img.getAttribute('data-selfoss-src'));
@@ -389,6 +385,17 @@ export default function Item({ currentTime, item, selected, expanded, setNavExpa
         [item]
     );
 
+    const externalLinkOnClick = useCallback(
+        (event) => {
+            event.stopPropagation();
+
+            if (canWrite) {
+                selfoss.entriesPage.markEntryRead(item.id, true);
+            }
+        },
+        [canWrite, item.id]
+    );
+
     const loadImagesOnClick = useCallback(
         (event) => loadImages({ event, setImagesLoaded, contentBlock }),
         []
@@ -544,7 +551,7 @@ export default function Item({ currentTime, item, selected, expanded, setNavExpa
                                 target="_blank"
                                 rel="noreferrer"
                                 accessKey="o"
-                                onClick={stopPropagation}
+                                onClick={externalLinkOnClick}
                             >
                                 <FontAwesomeIcon icon={icons.openWindow} /> {_('open_window')}
                             </a>
@@ -599,7 +606,7 @@ export default function Item({ currentTime, item, selected, expanded, setNavExpa
                         target="_blank"
                         rel="noreferrer"
                         accessKey="o"
-                        onClick={stopPropagation}
+                        onClick={externalLinkOnClick}
                     >
                         <FontAwesomeIcon icon={icons.openWindow} /> {_('open_window')}
                     </a>


### PR DESCRIPTION
Ten years after #451 (I'm feeling old...) it's time to try again to finally bring this tech-wise small but UX-wise major feature to upstream. The only reason to open the external link of an entry is to read said entry (especially when opened in the foreground - what most browsers do by default) - consequently the entry should be marked as read by default, too.

I believe that this should be default behaviour. There's still the possibility to make this an opt-in feature using a new `config.ini` option, but I'd strongly discourage it. If you want me to make it opt-in, let me know.

If you want to merge both # and #, ignore this PR and merge # instead. Merging any of the three PRs will automatically close the other two PRs.

Closes #
Closes #