### PR TITLE
client: Middle click on title to open entry in new tab

### DIFF
--- a/client/js/templates/Item.jsx
+++ b/client/js/templates/Item.jsx
@@ -446,11 +446,11 @@ export default function Item({ currentTime, item, selected, expanded, setNavExpa
                 className="entry-title"
                 onClick={titleOnClick}
             >
-                <span
+                <a
+                    href={item.link}
                     className="entry-title-link"
                     aria-expanded={expanded}
                     aria-current={selected}
-                    role="link"
                     tabIndex="0"
                     onKeyUp={handleKeyUp}
                     dangerouslySetInnerHTML={titleHtml}

--- a/client/styles/main.scss
+++ b/client/styles/main.scss
@@ -526,7 +526,8 @@ span.offline-count.diff {
 }
 
 .entry-title a {
-    color: var(--primary);
+    color: inherit;
+    text-decoration: none;
 }
 
 .entry.unread .entry-title {


### PR DESCRIPTION
Ten years after #452 (I'm feeling old...) it's time to try again to finally bring this tech-wise tiny but UX-wise major feature to upstream. I'm not aware of any good reason why one should be required to click on the tiny favicon to open an entry in a new tab.

I believe that this should be default behaviour. There's still the possibility to make this an opt-in feature using a new `config.ini` option, but I'd strongly discourage it - it's simple and basic, it doesn't affect other users, thus it shouldn't come with unnecessary complexity (like an option).

If you want to merge both # and #, ignore this PR and merge # instead. Merging any of the three PRs will automatically close the other two PRs.

Closes #
Closes #