### PR TITLE
helpers\WebClient: Add support for Digest authentication method

### DIFF
--- a/src/helpers/WebClient.php
+++ b/src/helpers/WebClient.php
@@ -63,6 +63,8 @@ class WebClient {
                 'handler' => $stack,
                 'timeout' => 60, // seconds
                 'curl' => [
+                    // Try the best authentication method when credentials are given.
+                    \CURLOPT_HTTPAUTH => \CURLAUTH_ANY,
                     // Guzzle will not send Accept-Encoding by default.
                     // https://github.com/guzzle/guzzle/pull/3215
                     // Delegate choosing compression method to curl.


### PR DESCRIPTION
We use curl Guzzle backend to make HTTP requests. When credentials are given in the URI, curl will send them in the request using `Basic` authentication method. Since the `Basic` method is deprecated, some servers require e.g. `Digest` instead. selfoss did not support that.

Let’s make selfoss use any HTTP authentication method the server offers in the `WWW-Authenticate` header using the `CURLAUTH_ANY` flag. This will make curl perform one extra GET request (only when credentials are provided) to obtain the authentication challenge.

One downside is that authentication will no longer be attempted if the challenge response does not return `401 Unauthorized` and `WWW-Authenticate` header. I can imagine a website that would return `200 OK` and a feed only containing public data when no credentials are provided, private data only being included when the request contains `Authorization` header with credentials for the unadvertised `Basic` auth. This patch would silently change such feeds to the public mode.

We are using `CURLAUTH_ANY` instead of `CURLAUTH_ANYSAFE` since some sites still only support `Basic` auth. Either flag will still choose the best available authentication method so it will be strictly better than the default `CURLAUTH_BASIC`.

Fixes: https://github.com/fossar/selfoss/issues/1486
