### PR TITLE
daos: Avoid double quotes for string literals

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@
 - Fix exporting OPML when there are tags that look like numbers ([#1439](https://github.com/fossar/selfoss/pull/1439))
 - Fix incorrect handling of tags in MySQL backend, which could result in OPML export being broken ([#1439](https://github.com/fossar/selfoss/pull/1439))
 - Fix sharing to Wallabag 2. ([#1465](https://github.com/fossar/selfoss/pull/1465))
+- Fix DB migration with SQLite that has double-quote string literals disabled (like on FreeBSD). ([#1489](https://github.com/fossar/selfoss/pull/1489))
 
 ### Customization changes
 - Custom spouts must explicitly pass `null` to `Item::__construct()` when they do not need the `extraData` argument. ([#1415](https://github.com/fossar/selfoss/pull/1415))

--- a/src/daos/Items.php
+++ b/src/daos/Items.php
@@ -119,14 +119,6 @@ class Items implements ItemsInterface {
         return $this->backend->lastId();
     }
 
-    public function getThumbnails(): array {
-        return $this->backend->getThumbnails();
-    }
-
-    public function getIcons(): array {
-        return $this->backend->getIcons();
-    }
-
     public function hasThumbnail(string $thumbnail): bool {
         return $this->backend->hasThumbnail($thumbnail);
     }

--- a/src/daos/ItemsInterface.php
+++ b/src/daos/ItemsInterface.php
@@ -120,20 +120,6 @@ interface ItemsInterface {
     /**
      * return all thumbnails
      *
-     * @return string[] array with thumbnails
-     */
-    public function getThumbnails(): array;
-
-    /**
-     * return all icons
-     *
-     * @return string[] array with all icons
-     */
-    public function getIcons(): array;
-
-    /**
-     * return all thumbnails
-     *
      * @param string $thumbnail name
      *
      * @return bool true if thumbnail is still in use

--- a/src/daos/mysql/Items.php
+++ b/src/daos/mysql/Items.php
@@ -456,40 +456,6 @@ class Items implements \daos\ItemsInterface {
     /**
      * return all thumbnails
      *
-     * @return string[] array with thumbnails
-     */
-    public function getThumbnails(): array {
-        $thumbnails = [];
-        $result = $this->database->exec('SELECT thumbnail
-                   FROM ' . $this->configuration->dbPrefix . 'items
-                   WHERE thumbnail!=""');
-        foreach ($result as $thumb) {
-            $thumbnails[] = $thumb['thumbnail'];
-        }
-
-        return $thumbnails;
-    }
-
-    /**
-     * return all icons
-     *
-     * @return string[] array with all icons
-     */
-    public function getIcons(): array {
-        $icons = [];
-        $result = $this->database->exec('SELECT icon
-                   FROM ' . $this->configuration->dbPrefix . 'items
-                   WHERE icon!=""');
-        foreach ($result as $icon) {
-            $icons[] = $icon['icon'];
-        }
-
-        return $icons;
-    }
-
-    /**
-     * return all thumbnails
-     *
      * @param string $thumbnail name
      *
      * @return bool true if thumbnail is still in use

--- a/src/daos/sqlite/Database.php
+++ b/src/daos/sqlite/Database.php
@@ -38,7 +38,7 @@ class Database implements \daos\DatabaseInterface {
 
     private function migrate(): void {
         // create tables if necessary
-        $result = @$this->exec('SELECT name FROM sqlite_master WHERE type = "table"');
+        $result = @$this->exec('SELECT "name" FROM "sqlite_master" WHERE "type" = \'table\'');
         $tables = [];
         foreach ($result as $table) {
             foreach ($table as $key => $value) {


### PR DESCRIPTION
[SQLite](https://www.sqlite.org/quirks.html#dblquote), [MySQL](https://dev.mysql.com/doc/refman/5.7/en/string-literals.html) but not [PostgreSQL](https://dev.mysql.com/doc/refman/5.7/en/string-literals.html) support using double quotes for string literals in some places. This is generally considered a bad practice and SQLite [recommends disabling the feature](https://www.sqlite.org/compile.html#recommended_compile_time_options), which FreeBSD does, resulting in an error on startup:

    no such column: table

Let’s fix the syntax to use ANSI SQL quoting style.
