### PR TITLE
Rework Authentication into separate services

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,9 @@
 - Source filters are stricter, they need to start and end with a `/`. ([#1423](https://github.com/fossar/selfoss/pull/1423))
 - OPML importer has been merged into the React client. ([#1442](https://github.com/fossar/selfoss/pull/1442))
 - Web requests will send `Accept-Encoding` header. ([#1482](https://github.com/fossar/selfoss/pull/1482))
+- Authentication system has been rewritten to allow more methods in the future. ([#1491](https://github.com/fossar/selfoss/pull/1491))
+- Authentication will now also log user out when the credentials in the config change. ([#1491](https://github.com/fossar/selfoss/pull/1491))
+- Requests from loopback IP address now give full access to all operations, not just update. Additionally, IPv6 loopback address is recognized and proxies are ignored. ([#1491](https://github.com/fossar/selfoss/pull/1491))
 
 #### For developers
 - Back-end source code is now checked using [PHPStan](https://phpstan.org/). ([#1409](https://github.com/fossar/selfoss/pull/1409))

--- a/src/common.php
+++ b/src/common.php
@@ -69,6 +69,15 @@ $container
     ->register(helpers\Authentication::class)
     ->setShared(true)
 ;
+
+$container
+    ->register(
+        helpers\Authentication\AuthenticationService::class,
+        [new Slince\Di\Reference(helpers\Authentication\AuthenticationFactory::class), 'create']
+    )
+    ->setShared(true)
+;
+
 $container
     ->register(helpers\Session::class)
     ->setShared(true)

--- a/src/controllers/About.php
+++ b/src/controllers/About.php
@@ -54,7 +54,7 @@ class About {
                 'htmlTitle' => trim($this->configuration->htmlTitle), // string
                 'allowPublicUpdate' => $this->configuration->allowPublicUpdateAccess, // bool
                 'publicMode' => $this->configuration->public, // bool
-                'authEnabled' => $this->authentication->enabled() === true, // bool
+                'authEnabled' => $this->authentication->enabled(), // bool
                 'readingSpeed' => $this->configuration->readingSpeedWpm > 0 ? $this->configuration->readingSpeedWpm : null, // ?int
                 'language' => $this->configuration->language === '0' ? null : $this->configuration->language, // ?string
                 'userCss' => file_exists(BASEDIR . '/user.css') ? filemtime(BASEDIR . '/user.css') : null, // ?int

--- a/src/controllers/Authentication.php
+++ b/src/controllers/Authentication.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 namespace controllers;
 
-use helpers;
+use helpers\Authentication\AuthenticationService;
 use helpers\View;
 
 /**
  * Controller for user related tasks
  */
 class Authentication {
-    private helpers\Authentication $authentication;
+    private AuthenticationService $authenticationService;
     private View $view;
 
-    public function __construct(helpers\Authentication $authentication, View $view) {
-        $this->authentication = $authentication;
+    public function __construct(AuthenticationService $authenticationService, View $view) {
+        $this->authenticationService = $authenticationService;
         $this->view = $view;
     }
 
@@ -26,17 +26,11 @@ class Authentication {
     public function login(): void {
         $error = null;
 
-        if (isset($_REQUEST['username'])) {
-            $username = $_REQUEST['username'];
-        } else {
-            $username = '';
+        if (!isset($_REQUEST['username'])) {
             $error = 'no username given';
         }
 
-        if (isset($_REQUEST['password'])) {
-            $password = $_REQUEST['password'];
-        } else {
-            $password = '';
+        if (!isset($_REQUEST['password'])) {
             $error = 'no password given';
         }
 
@@ -47,7 +41,8 @@ class Authentication {
             ]);
         }
 
-        if ($this->authentication->login($username, $password)) {
+        // The function automatically checks the request for credentials.
+        if ($this->authenticationService->isPrivileged()) {
             $this->view->jsonSuccess([
                 'success' => true,
             ]);
@@ -64,7 +59,7 @@ class Authentication {
      * json
      */
     public function logout(): void {
-        $this->authentication->logout();
+        $this->authenticationService->destroy();
         $this->view->jsonSuccess([
             'success' => true,
         ]);

--- a/src/controllers/Helpers/HashPassword.php
+++ b/src/controllers/Helpers/HashPassword.php
@@ -24,7 +24,7 @@ final class HashPassword {
      * json
      */
     public function hash(): void {
-        $this->authentication->needsLoggedIn();
+        $this->authentication->ensureIsPrivileged();
 
         if (!isset($_POST['password'])) {
             $this->view->jsonError([

--- a/src/controllers/Index.php
+++ b/src/controllers/Index.php
@@ -60,7 +60,7 @@ class Index {
             return;
         }
 
-        $this->authentication->needsLoggedInOrPublicMode();
+        $this->authentication->ensureCanRead();
 
         // load tags
         $tags = $this->tagsDao->getWithUnread();

--- a/src/controllers/Items.php
+++ b/src/controllers/Items.php
@@ -44,7 +44,7 @@ class Items {
      * @param ?string $itemId ID of item to mark as read
      */
     public function mark(?string $itemId = null): void {
-        $this->authentication->needsLoggedIn();
+        $this->authentication->ensureIsPrivileged();
 
         $ids = null;
         if ($itemId !== null) {
@@ -84,7 +84,7 @@ class Items {
      * @param string $itemId id of an item to mark as unread
      */
     public function unmark(string $itemId): void {
-        $this->authentication->needsLoggedIn();
+        $this->authentication->ensureIsPrivileged();
 
         try {
             $itemId = Misc::forceId($itemId);
@@ -106,7 +106,7 @@ class Items {
      * @param string $itemId id of an item to starr
      */
     public function starr(string $itemId): void {
-        $this->authentication->needsLoggedIn();
+        $this->authentication->ensureIsPrivileged();
 
         try {
             $itemId = Misc::forceId($itemId);
@@ -127,7 +127,7 @@ class Items {
      * @param string $itemId id of an item to unstarr
      */
     public function unstarr(string $itemId): void {
-        $this->authentication->needsLoggedIn();
+        $this->authentication->ensureIsPrivileged();
 
         try {
             $itemId = Misc::forceId($itemId);
@@ -146,7 +146,7 @@ class Items {
      * json
      */
     public function listItems(): void {
-        $this->authentication->needsLoggedInOrPublicMode();
+        $this->authentication->ensureCanRead();
 
         // parse params
         $options = new ItemOptions($_GET);

--- a/src/controllers/Items/Stats.php
+++ b/src/controllers/Items/Stats.php
@@ -30,7 +30,7 @@ class Stats {
      * json
      */
     public function stats(): void {
-        $this->authentication->needsLoggedInOrPublicMode();
+        $this->authentication->ensureCanRead();
 
         $stats = $this->itemsDao->stats();
 

--- a/src/controllers/Items/Sync.php
+++ b/src/controllers/Items/Sync.php
@@ -39,7 +39,7 @@ class Sync {
      * json
      */
     public function sync(): void {
-        $this->authentication->needsLoggedInOrPublicMode();
+        $this->authentication->ensureCanRead();
 
         if (isset($_GET['since'])) {
             $params = $_GET;
@@ -113,7 +113,7 @@ class Sync {
      * Items statuses bulk update.
      */
     public function updateStatuses(): void {
-        $this->authentication->needsLoggedIn();
+        $this->authentication->ensureIsPrivileged();
 
         if (isset($_POST['updatedStatuses'])) {
             $updatedStatuses = $_POST['updatedStatuses'];

--- a/src/controllers/Opml/Export.php
+++ b/src/controllers/Opml/Export.php
@@ -79,7 +79,7 @@ class Export {
      * @note Uses the selfoss namespace to store selfoss-specific information
      */
     public function export(): void {
-        $this->authentication->needsLoggedIn();
+        $this->authentication->ensureIsPrivileged();
 
         $this->logger->debug('start OPML export');
         $this->writer->openMemory();

--- a/src/controllers/Opml/Import.php
+++ b/src/controllers/Opml/Import.php
@@ -42,7 +42,7 @@ class Import {
      * @note Borrows from controllers/Sources.php:write
      */
     public function add(): void {
-        $this->authentication->needsLoggedIn();
+        $this->authentication->ensureIsPrivileged();
 
         http_response_code(400);
 

--- a/src/controllers/Rss.php
+++ b/src/controllers/Rss.php
@@ -42,9 +42,9 @@ class Rss {
 
         $this->feedWriter->setTitle($this->configuration->rssTitle);
         $this->feedWriter->setChannelElement('description', '');
-        $this->feedWriter->setSelfLink($this->view->base . 'feed');
+        $this->feedWriter->setSelfLink($this->view->getBaseUrl() . 'feed');
 
-        $this->feedWriter->setLink($this->view->base);
+        $this->feedWriter->setLink($this->view->getBaseUrl());
 
         // get sources
         $lastSourceId = 0;

--- a/src/controllers/Rss.php
+++ b/src/controllers/Rss.php
@@ -38,7 +38,7 @@ class Rss {
      * rss feed
      */
     public function rss(): void {
-        $this->authentication->needsLoggedInOrPublicMode();
+        $this->authentication->ensureCanRead();
 
         $this->feedWriter->setTitle($this->configuration->rssTitle);
         $this->feedWriter->setChannelElement('description', '');

--- a/src/controllers/Sources.php
+++ b/src/controllers/Sources.php
@@ -37,7 +37,7 @@ class Sources {
      * json
      */
     public function show(): void {
-        $this->authentication->needsLoggedIn();
+        $this->authentication->ensureIsPrivileged();
 
         // get available spouts
         $spouts = $this->spoutLoader->all();
@@ -61,7 +61,7 @@ class Sources {
      * json
      */
     public function add(): void {
-        $this->authentication->needsLoggedIn();
+        $this->authentication->ensureIsPrivileged();
 
         $spouts = $this->spoutLoader->all();
 
@@ -75,7 +75,7 @@ class Sources {
      * json
      */
     public function params(): void {
-        $this->authentication->needsLoggedIn();
+        $this->authentication->ensureIsPrivileged();
 
         if (!isset($_GET['spout'])) {
             $this->view->error('no spout type given');
@@ -102,7 +102,7 @@ class Sources {
      * @param string $id ID of source to remove
      */
     public function remove(string $id): void {
-        $this->authentication->needsLoggedIn();
+        $this->authentication->ensureIsPrivileged();
 
         try {
             $id = Misc::forceId($id);
@@ -126,7 +126,7 @@ class Sources {
      * json
      */
     public function listSources(): void {
-        $this->authentication->needsLoggedIn();
+        $this->authentication->ensureIsPrivileged();
 
         // load sources
         $sources = $this->sourcesDao->getWithIcon();
@@ -145,7 +145,7 @@ class Sources {
      * json
      */
     public function spouts(): void {
-        $this->authentication->needsLoggedIn();
+        $this->authentication->ensureIsPrivileged();
 
         $spouts = $this->spoutLoader->all();
         $this->view->jsonSuccess($spouts);
@@ -156,7 +156,7 @@ class Sources {
      * json
      */
     public function stats(): void {
-        $this->authentication->needsLoggedInOrPublicMode();
+        $this->authentication->ensureCanRead();
 
         // load sources
         $sources = $this->sourcesDao->getWithUnread();

--- a/src/controllers/Sources/Write.php
+++ b/src/controllers/Sources/Write.php
@@ -51,7 +51,7 @@ class Write {
      * @param ?string $id ID of source to update, or null to create a new one
      */
     public function write(?string $id = null): void {
-        $this->authentication->needsLoggedIn();
+        $this->authentication->ensureIsPrivileged();
 
         $data = $this->request->getData();
 

--- a/src/controllers/Tags.php
+++ b/src/controllers/Tags.php
@@ -70,7 +70,7 @@ class Tags {
      * set tag color
      */
     public function color(): void {
-        $this->authentication->needsLoggedIn();
+        $this->authentication->ensureIsPrivileged();
 
         $data = $this->request->getData();
 
@@ -101,7 +101,7 @@ class Tags {
      * html
      */
     public function listTags(): void {
-        $this->authentication->needsLoggedInOrPublicMode();
+        $this->authentication->ensureCanRead();
 
         $tags = $this->tagsDao->getWithUnread();
 

--- a/src/helpers/Authentication.php
+++ b/src/helpers/Authentication.php
@@ -36,7 +36,6 @@ class Authentication {
             return;
         }
 
-        $this->session->start();
         if ($this->session->getBool('loggedin', false)) {
             $this->loggedin = true;
             $this->logger->debug('logged in using valid session');

--- a/src/helpers/Authentication/AuthenticationFactory.php
+++ b/src/helpers/Authentication/AuthenticationFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+// SPDX-FileCopyrightText: 2024 Jan Tojnar <jtojnar@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace helpers\Authentication;
+
+use helpers\Configuration;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Factory that creates `AuthenticationService` based on the configuration.
+ */
+final class AuthenticationFactory {
+    private Configuration $configuration;
+    private ContainerInterface $container;
+
+    public function __construct(Configuration $configuration, ContainerInterface $container) {
+        $this->configuration = $configuration;
+        $this->container = $container;
+    }
+
+    public function create(): AuthenticationService {
+        if (!$this->useCredentials() || $this->isCli() || $this->isLocalIp()) {
+            return $this->container->get(Services\Trust::class);
+        }
+
+        return $this->container->get(Services\RequestOrSession::class);
+    }
+
+    private function isCli(): bool {
+        return PHP_SAPI === 'cli';
+    }
+
+    private function isLocalIp(): bool {
+        // We cannot trust these IP addresses but we know they are likely not local.
+        if (isset($_SERVER['HTTP_X_FORWARDED_FOR']) || isset($_SERVER['HTTP_FORWARDED'])) {
+            return false;
+        }
+
+        return $_SERVER['REMOTE_ADDR'] === '::1' || $_SERVER['REMOTE_ADDR'] === '127.0.0.1';
+    }
+
+    private function useCredentials(): bool {
+        return strlen($this->configuration->username) > 0 && strlen($this->configuration->password) > 0;
+    }
+}

--- a/src/helpers/Authentication/AuthenticationService.php
+++ b/src/helpers/Authentication/AuthenticationService.php
@@ -1,0 +1,34 @@
+<?php
+
+// SPDX-FileCopyrightText: 2024 Jan Tojnar <jtojnar@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace helpers\Authentication;
+
+/**
+ * Must be implemented by any authentication service.
+ */
+interface AuthenticationService {
+    /**
+     * Checks whether user is authorized to read (logged in/public mode).
+     */
+    public function canRead(): bool;
+
+    /**
+     * Checks whether user is authorized to update sources (logged in/public update mode).
+     */
+    public function canUpdate(): bool;
+
+    /**
+     * Checks whether user is authorized to perform a privileged action
+     * or access privileged information.
+     */
+    public function isPrivileged(): bool;
+
+    /**
+     * Give up authorization.
+     */
+    public function destroy(): void;
+}

--- a/src/helpers/Authentication/Services/RequestOrSession.php
+++ b/src/helpers/Authentication/Services/RequestOrSession.php
@@ -1,0 +1,137 @@
+<?php
+
+// SPDX-FileCopyrightText: 2024 Jan Tojnar <jtojnar@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace helpers\Authentication\Services;
+
+use helpers\Authentication\AuthenticationService;
+use helpers\Configuration;
+use helpers\Session;
+use Monolog\Logger;
+
+/**
+ * Authentication method that verifies credentials given using
+ * the following means against those specified in configuration file:
+ *
+ *  - `username` and `password` in `POST` data
+ *  - `username` and `password` in `GET` query string
+ *
+ * Additionally, it will persist the authorization in a session.
+ */
+final class RequestOrSession implements AuthenticationService {
+    private const SESSION_KEY = 'authorized';
+
+    private Configuration $configuration;
+    private Logger $logger;
+    private Session $session;
+
+    private ?bool $authorized = null;
+
+    public function __construct(Configuration $configuration, Logger $logger, Session $session) {
+        $this->configuration = $configuration;
+        $this->logger = $logger;
+        $this->session = $session;
+    }
+
+    public function canRead(): bool {
+        return $this->configuration->public || $this->isPrivileged();
+    }
+
+    public function canUpdate(): bool {
+        return $this->configuration->allowPublicUpdateAccess || $this->isPrivileged();
+    }
+
+    public function isPrivileged(): bool {
+        if ($this->authorized === null) {
+            $this->authorized = $this->checkSession() || $this->checkRequest();
+        }
+
+        return $this->authorized;
+    }
+
+    /**
+     * Checks if there is a authorized session and matches it against the credentials in the config.
+     */
+    private function checkSession(): bool {
+        $authorization = $this->session->getString(self::SESSION_KEY);
+
+        if ($authorization === null) {
+            $this->logger->debug('Session does not contain authorization string');
+        } elseif ($authorization === $this->getExpectedAuthorizationSession()) {
+            $this->logger->debug('Access granted based on a session');
+
+            return true;
+        }
+
+        $this->logger->debug('Session does not contain valid auth (credentials changed)');
+
+        return false;
+    }
+
+    /**
+     * Checks if the request contains credentials and stores the authorization in a session if it does.
+     */
+    private function checkRequest(): bool {
+        if (!isset($_REQUEST['username']) || !isset($_REQUEST['password'])) {
+            return false;
+        }
+
+        if ($this->verifyCredentials($_REQUEST['username'], $_REQUEST['password'])) {
+            $this->logger->debug('Access granted based on request credentials');
+            $this->saveAuthorization();
+
+            return true;
+        }
+
+        $this->logger->debug('Request credentials not valid');
+
+        return false;
+    }
+
+    /**
+     * Generates a session value that will serve as a proof of authentication.
+     *
+     * We are storing the username & password hash to ensure clients
+     * are logged out when credentials change.
+     */
+    private function getExpectedAuthorizationSession(): string {
+        // We are using the password hash from the config for simplicity.
+        // This will cause users to be signed out if they rehash the password but that should be rare.
+        return $this->configuration->username . ':::' . $this->configuration->password;
+    }
+
+    /**
+     * Checks credentials against config.
+     */
+    private function verifyCredentials(string $username, string $password): bool {
+        return $username === $this->configuration->username && $this->verifyPassword($password);
+    }
+
+    /**
+     * Checks password against config.
+     */
+    private function verifyPassword(string $password): bool {
+        $hashedPassword = $this->configuration->password;
+
+        // Passwords hashed with password_hash start with $, otherwise use the legacy path.
+        return
+            $hashedPassword !== '' && $hashedPassword[0] === '$'
+            ? password_verify($password, $hashedPassword)
+            : hash('sha512', $this->configuration->salt . $password) === $hashedPassword;
+    }
+
+    private function saveAuthorization(): void {
+        $authorization = $this->getExpectedAuthorizationSession();
+        $this->session->setString(self::SESSION_KEY, $authorization);
+    }
+
+    public function destroy(): void {
+        $this->authorized = false;
+        $this->session->setString(self::SESSION_KEY, null);
+        $this->session->destroy();
+        $this->logger->debug('Logged out and destroyed session');
+    }
+}

--- a/src/helpers/Authentication/Services/Trust.php
+++ b/src/helpers/Authentication/Services/Trust.php
@@ -1,0 +1,33 @@
+<?php
+
+// SPDX-FileCopyrightText: 2024 Jan Tojnar <jtojnar@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace helpers\Authentication\Services;
+
+use helpers\Authentication\AuthenticationService;
+
+/**
+ * Trivial authentication service that allows any access.
+ *
+ * To be used for CLI or when authentication is disabled.
+ */
+final class Trust implements AuthenticationService {
+    public function canRead(): bool {
+        return true;
+    }
+
+    public function canUpdate(): bool {
+        return true;
+    }
+
+    public function isPrivileged(): bool {
+        return true;
+    }
+
+    public function destroy(): void {
+        // Nothing to rescind.
+    }
+}

--- a/src/helpers/Session.php
+++ b/src/helpers/Session.php
@@ -62,17 +62,17 @@ class Session {
         }
     }
 
-    public function getBool(string $name, bool $default): bool {
+    public function getString(string $name): ?string {
         $this->start();
 
-        if (array_key_exists($name, $_SESSION) && is_bool($_SESSION[$name])) {
+        if (array_key_exists($name, $_SESSION) && is_string($_SESSION[$name])) {
             return $_SESSION[$name];
         }
 
-        return $default;
+        return null;
     }
 
-    public function setBool(string $name, bool $value): void {
+    public function setString(string $name, ?string $value): void {
         $this->start();
 
         $_SESSION[$name] = $value;

--- a/src/helpers/Session.php
+++ b/src/helpers/Session.php
@@ -16,6 +16,8 @@ use Monolog\Logger;
 
 /**
  * Helper class for session management.
+ *
+ * This must be the only place to call `session_start()`.
  */
 class Session {
     private bool $started = false;
@@ -61,6 +63,8 @@ class Session {
     }
 
     public function getBool(string $name, bool $default): bool {
+        $this->start();
+
         if (array_key_exists($name, $_SESSION) && is_bool($_SESSION[$name])) {
             return $_SESSION[$name];
         }
@@ -69,10 +73,16 @@ class Session {
     }
 
     public function setBool(string $name, bool $value): void {
+        $this->start();
+
         $_SESSION[$name] = $value;
     }
 
     public function destroy(): void {
+        if (!$this->started) {
+            return;
+        }
+
         session_destroy();
     }
 }

--- a/src/helpers/View.php
+++ b/src/helpers/View.php
@@ -21,7 +21,7 @@ use Psr\Http\Message\ResponseInterface;
  */
 class View {
     /** Current base url */
-    public string $base = '';
+    private ?string $baseUrl = null;
 
     private Configuration $configuration;
 
@@ -30,7 +30,6 @@ class View {
      */
     public function __construct(Configuration $configuration) {
         $this->configuration = $configuration;
-        $this->base = $this->getBaseUrl();
     }
 
     /**
@@ -39,6 +38,14 @@ class View {
      * globale server variables ($_SERVER).
      */
     public function getBaseUrl(): string {
+        if ($this->baseUrl === null) {
+            $this->baseUrl = $this->makeBaseUrl();
+        }
+
+        return $this->baseUrl;
+    }
+
+    private function makeBaseUrl(): string {
         // base url in config.ini file
         $base = $this->configuration->baseUrl;
         if ($base !== '') {

--- a/tests/integration/helpers/selfoss_api.py
+++ b/tests/integration/helpers/selfoss_api.py
@@ -7,6 +7,13 @@ class SelfossApi:
         # We still use cookies for authentication so let’s persist them across requests.
         self.session = requests.Session()
 
+        self.session.headers.update(
+            {
+                # Pretend that we are coming from a different computer so that local authentication bypass does not happen.
+                "X-Forwarded-For": "1.2.3.4",
+            }
+        )
+
     def login(self, username, password):
         r = self.session.post(
             f"{self.base_uri}/login",

--- a/tests/integration/run.py
+++ b/tests/integration/run.py
@@ -23,8 +23,8 @@ class BasicWorkflowTest(SelfossIntegration):
                 url=fibonacci_feed_uri,
             )
             assert (
-                "Adding source is privileged operation and should fail without login."
-            )
+                False
+            ), "Adding source is privileged operation and should fail without login."
         except requests.exceptions.HTTPError as e:
             assert (
                 e.response.status_code == 403


### PR DESCRIPTION

This is a from-scratch rewrite, moving a bit closer to Single Responsibility Principle.

We split handling of credentials-in-config and always-open authentication systems.
In the future, we will be able implement more methods this way.

This was motivated by session code being called in constructor,
which would break in CLI with Tracy strict mode.

For now, we are just porting the Authentication helper and controller.

Additionally:

- Session verification now also checks if the credentials in the config did not change.
- Requests from loopback IP address now give full access to all operations, not just update.
- IPv6 loopback address is recognized as well.
- Requests forwarded by proxies are filtered out since local reverse proxies might come from loopback as well.

One thing I do not like that any request with credentials will automatically
persist the login to session but removing that feature can be done later.