### PR TITLE
docs: clarify project status

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,16 @@
 
 ## Reporting an issue
 
-If you discover a bug or wish to have a feature added, [report it to the issue tracker](https://github.com/fossar/selfoss/issues/new). Try to describe the problem in as much detail as possible.
+If you discover a bug, please [report it to the issue tracker](https://github.com/fossar/selfoss/issues/new). Try to describe the problem in as much detail as possible.
+
+You can also ask for a new feature but unless I would personally use it, I will probably not find time to implement it.
 
 
 ## Contributing code
 
 We accept [pull requests](https://github.com/fossar/selfoss/compare) with your changes.
+
+For larger changes, please discuss it in an issue first, to avoid potentially wasting effort.
 
 Every patch is expected to adhere to our coding style, which is checked automatically by CI. You can install the checkers locally using `npm run install-dependencies`, and then run the checks using `npm run check` before submitting a pull request. There is also `npm run fix`, that will attempt to fix the formatting.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ selfoss is a multipurpose RSS reader and feed aggregation web application. It al
 
 For more information visit our [web site](https://selfoss.aditu.de).
 
+
+## Status
+
+selfoss is currently maintained by Jan Tojnar in his free time. Due to the [limited capacity](https://github.com/jtojnar/jtojnar), maintenance is prioritized over new features. Pull requests are welcome, see the [Contributing](CONTRIBUTING.md) guide.
+
+
 ## Download
 
 * [Stable releases](https://github.com/fossar/selfoss/releases) – if you just want to use selfoss.


### PR DESCRIPTION
Having read Hintjens’s [Social Architecture](https://hintjens.gitbooks.io/social-architecture/content/) book, I want to try to build a community around selfoss, so that I am not the sole developer forever.

Until then, I need to document the current state so that people do not expect more than I have the capacity to provide.

I have also added a [README to my GitHub profile](https://github.com/jtojnar/jtojnar) that describes my work style and availability.