### PR TITLE
README: Remove the latest build link

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -164,7 +164,6 @@ jobs:
           file: ${{ steps.zipball.outputs.file_name }}
           name: selfoss.zip
           version: ${{ steps.zipball.outputs.version }}
-          tags: "version:latest"
 
       - name: Prepare a changelog
         run: |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ selfoss is currently maintained by Jan Tojnar in his free time. Due to the [limi
 ## Download
 
 * [Stable releases](https://github.com/fossar/selfoss/releases) – if you just want to use selfoss.
-* [Development builds](https://cloudsmith.io/~fossar/repos/selfoss-git/packages/) ([latest](https://cloudsmith.io/~fossar/repos/selfoss-git/packages/?q=version%3Alatest)) – if you want to try unreleased features or bug fixes, or help testing them. Hosted by [Cloudsmith](https://cloudsmith.com)
+* [Development builds](https://cloudsmith.io/~fossar/repos/selfoss-git/packages/) – if you want to try unreleased features or bug fixes, or help testing them. Hosted by [Cloudsmith](https://cloudsmith.com)
 * [Git-tracked source code](https://github.com/fossar/selfoss) – if you want to join selfoss development. Some [assembly](#development) required.
 
 


### PR DESCRIPTION
This is still broken:  https://github.com/cloudsmith-io/action/issues/60
