### PR TITLE
search: Fix on PHP 8.4

### DIFF
--- a/src/helpers/Search.php
+++ b/src/helpers/Search.php
@@ -24,7 +24,7 @@ class Search {
 
         // Split search terms by space (but save it inside quotes)...
         /** @var string[] */ // For PHPStan: The only case where null appears is array{null} when the $string is empty.
-        $parts = str_getcsv(trim($search), ' ');
+        $parts = str_getcsv(trim($search), ' ', '"', '\\');
 
         return array_filter(
             $parts,

--- a/tests/integration/helpers/selfoss_api.py
+++ b/tests/integration/helpers/selfoss_api.py
@@ -34,9 +34,10 @@ class SelfossApi:
 
         return r.json()
 
-    def get_items(self):
+    def get_items(self, **params):
         r = self.session.get(
             f"{self.base_uri}/items",
+            params=params,
         )
         r.raise_for_status()
 

--- a/tests/integration/run.py
+++ b/tests/integration/run.py
@@ -57,6 +57,11 @@ class BasicWorkflowTest(SelfossIntegration):
         assert not items[0]["unread"], "First item should now be marked as read"
         assert items[0]["starred"], "First item should now be starred"
 
+        items = selfoss_api.get_items(search="3")
+        assert (
+            len(items) == 5
+        ), "Search should find five fibonacci sequence numbers containing the digit 3"
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
On PHP 8.4 search would fail with the following:

    str_getcsv(): the $escape parameter must be provided as its default value will change

As per <https://www.php.net/manual/en/function.str-getcsv.php>, relying on the default value of escape is now deprecated.

Also add a test to ensure search continues to work.


Fixes: https://github.com/fossar/selfoss/issues/1516
