### PR TITLE
Fix TypeError when refreshing entry statuses

### DIFF
--- a/client/js/templates/EntriesPage.jsx
+++ b/client/js/templates/EntriesPage.jsx
@@ -729,7 +729,7 @@ class StateHolder extends React.Component {
             const newStatus = entryStatuses.find(
                 (entryStatus) => entryStatus.id == id,
             );
-            if (newStatus !== null) {
+            if (newStatus) {
                 this.starEntryInView(id, newStatus.starred);
                 this.markEntryInView(id, newStatus.unread);
             }


### PR DESCRIPTION
Fixes 'TypeError: can't access property starred, r is undefined' introduced in 00cf3d6 (#1512).