### PR TITLE
WIP: Shortcuts streamline & help page

### DIFF
--- a/client/js/shortcuts.ts
+++ b/client/js/shortcuts.ts
@@ -33,7 +33,7 @@ interface IKeybinding {
     action: KeyboardEventHandler;
 }
 
-const KEYBINDINGS: { [keycombo: string]: IKeybinding } = {
+export const KEYBINDINGS: { [keycombo: string]: IKeybinding } = {
     Space: {
         description: 'select and open next entry',
         action: () => {
@@ -178,6 +178,10 @@ const KEYBINDINGS: { [keycombo: string]: IKeybinding } = {
                 .click();
         },
     },
+    "?": {
+        description: "open shortcut help",
+        
+    }
 };
 
 function makeKeybindingsMap(): KeybindingsMap {
@@ -194,6 +198,7 @@ function makeKeybindingsMap(): KeybindingsMap {
     }
     return keybindingsMap;
 }
+
 
 /**
  * Set up shortcuts on document.

--- a/client/js/shortcuts.ts
+++ b/client/js/shortcuts.ts
@@ -1,4 +1,4 @@
-import { tinykeys } from 'tinykeys';
+import { KeybindingsMap, tinykeys } from 'tinykeys';
 import selfoss from './selfoss-base';
 import { Direction } from './helpers/navigation';
 
@@ -21,146 +21,183 @@ function ignoreWhenInteracting(
 }
 
 /**
- * Set up shortcuts on document.
+ * A selfoss-side definition of all keybindings
+ * This is used to:
+ * - Limit boilerplate
+ * - Generate a tinykeys compatible KeybindingsMap (@see makeKeybindingsMap)
+ * - Generate a shortcut overview
  */
-export default function makeShortcuts(): () => void {
-    return tinykeys(window, {
-        // 'space': next article
-        Space: ignoreWhenInteracting((event: KeyboardEvent): void => {
-            event.preventDefault();
+interface IKeybinding {
+    readableName?: string;
+    description: string;
+    action: KeyboardEventHandler;
+}
+
+const KEYBINDINGS: { [keycombo: string]: IKeybinding } = {
+    Space: {
+        description: 'select and open next entry',
+        action: () => {
             selfoss.entriesPage?.jumpToNext();
-        }),
-
-        // 'n': next article
-        n: ignoreWhenInteracting((event: KeyboardEvent): void => {
-            event.preventDefault();
-            selfoss.entriesPage?.nextPrev(Direction.NEXT, false);
-        }),
-
-        // 'right cursor': next article
-        ArrowRight: ignoreWhenInteracting((event: KeyboardEvent): void => {
-            event.preventDefault();
-            selfoss.entriesPage?.entryNav(Direction.NEXT);
-        }),
-
-        // 'j': next article
-        j: ignoreWhenInteracting((event: KeyboardEvent): void => {
-            event.preventDefault();
+        },
+    },
+    j: {
+        description: 'select and open next entry',
+        action: () => {
             selfoss.entriesPage?.nextPrev(Direction.NEXT, true);
-        }),
-
-        // 'shift+space': previous article
-        'Shift+Space': ignoreWhenInteracting((event: KeyboardEvent): void => {
-            event.preventDefault();
+        },
+    },
+    n: {
+        description: 'select next entry',
+        action: () => {
+            selfoss.entriesPage?.nextPrev(Direction.NEXT, false);
+        },
+    },
+    Arrowright: {
+        readableName: '→',
+        description: 'select next entry (and open it when the current is open)',
+        action: () => {
+            selfoss.entriesPage?.entryNav(Direction.NEXT);
+        },
+    },
+    'Shift+Space': {
+        description: 'select and open previous entry',
+        action: () => {
             selfoss.entriesPage?.nextPrev(Direction.PREV, true);
-        }),
-
-        // 'p': previous article
-        p: ignoreWhenInteracting((event: KeyboardEvent): void => {
-            event.preventDefault();
+        },
+    },
+    p: {
+        description: 'select previous entry',
+        action: () => {
             selfoss.entriesPage?.nextPrev(Direction.PREV, false);
-        }),
-
-        // 'left': previous article
-        ArrowLeft: ignoreWhenInteracting((event: KeyboardEvent): void => {
-            event.preventDefault();
+        },
+    },
+    ArrowLeft: {
+        readableName: '←',
+        description:
+            'select previous entry (and open it when the current is open)',
+        action: () => {
             selfoss.entriesPage?.entryNav(Direction.PREV);
-        }),
-
-        // 'k': previous article
-        k: ignoreWhenInteracting((event: KeyboardEvent): void => {
-            event.preventDefault();
+        },
+    },
+    k: {
+        description: 'select and open previous entry',
+        action: () => {
             selfoss.entriesPage?.nextPrev(Direction.PREV, true);
-        }),
-
-        // 's': star/unstar
-        s: ignoreWhenInteracting((event: KeyboardEvent): void => {
-            event.preventDefault();
+        },
+    },
+    s: {
+        description:
+            'mark and unmark current selected entry as starred/unstarred',
+        action: () => {
             selfoss.entriesPage?.toggleSelectedStarred();
-        }),
-
-        // 'm': mark/unmark
-        m: ignoreWhenInteracting((event: KeyboardEvent): void => {
-            event.preventDefault();
+        },
+    },
+    m: {
+        description: 'mark and unmark current selected entry as read/unread',
+        action: () => {
             selfoss.entriesPage?.toggleSelectedRead();
-        }),
-
-        // 'o': open/close entry
-        o: ignoreWhenInteracting((event: KeyboardEvent): void => {
-            event.preventDefault();
-            selfoss.entriesPage?.toggleSelectedExpanded();
-        }),
-
-        // 'Shift + o': close open entries
-        'Shift+o': ignoreWhenInteracting((event: KeyboardEvent): void => {
-            event.preventDefault();
-            selfoss.entriesPage?.collapseAllEntries();
-        }),
-
-        // 'v': open target
-        v: ignoreWhenInteracting((event: KeyboardEvent): void => {
-            event.preventDefault();
-            selfoss.entriesPage?.openSelectedTarget();
-        }),
-
-        // 'Shift + v': open target and mark read
-        'Shift+v': ignoreWhenInteracting((event: KeyboardEvent): void => {
-            event.preventDefault();
-            selfoss.entriesPage?.openSelectedTargetAndMarkRead();
-        }),
-
-        // 'r': Reload the current view
-        r: ignoreWhenInteracting((event: KeyboardEvent): void => {
-            event.preventDefault();
-            selfoss.entriesPage?.reload();
-        }),
-
-        // 'Shift + r': Refresh sources
-        'Shift+r': ignoreWhenInteracting((event: KeyboardEvent): void => {
-            event.preventDefault();
-            document.querySelector<HTMLButtonElement>('#nav-refresh').click();
-        }),
-
-        // 'Control+m': mark all as read
-        'Control+m': ignoreWhenInteracting((event: KeyboardEvent): void => {
-            event.preventDefault();
+        },
+    },
+    'Control+m': {
+        description: 'mark all as read',
+        action: () => {
             document.querySelector<HTMLButtonElement>('#nav-mark').click();
-        }),
-
-        // 't': throw (mark as read & open next)
-        t: ignoreWhenInteracting((event: KeyboardEvent): void => {
-            event.preventDefault();
+        },
+    },
+    o: {
+        description: 'open / close current entry',
+        action: () => {
+            selfoss.entriesPage?.toggleSelectedExpanded();
+        },
+    },
+    'Shift+o': {
+        description: 'close all open entries',
+        action: () => {
+            selfoss.entriesPage?.collapseAllEntries();
+        },
+    },
+    v: {
+        description: 'open url of current entry in new tab/window',
+        action: () => {
+            selfoss.entriesPage?.openSelectedTarget();
+        },
+    },
+    'Shift+v': {
+        description:
+            'open url of current entry in new tab/window and mark read',
+        action: () => {
+            selfoss.entriesPage?.openSelectedTargetAndMarkRead();
+        },
+    },
+    r: {
+        description: 'reload the list',
+        action: () => {
+            selfoss.entriesPage?.reload();
+        },
+    },
+    'Shift+r': {
+        description: 'refresh sources',
+        action: () => {
+            document.querySelector<HTMLButtonElement>('#nav-refresh').click();
+        },
+    },
+    t: {
+        description: 'throw current entry to next (mark as read & open next)',
+        action: () => {
             selfoss.entriesPage?.throw(Direction.NEXT);
-        }),
-
-        // throw (mark as read & open previous)
-        'Shift+t': ignoreWhenInteracting((event: KeyboardEvent): void => {
-            event.preventDefault();
+        },
+    },
+    'Shift+t': {
+        description:
+            'throw current entry to previous (mark as read & open previous)',
+        action: () => {
             selfoss.entriesPage?.throw(Direction.PREV);
-        }),
-
-        // 'Shift+n': switch to newest items overview / menu item
-        'Shift+n': ignoreWhenInteracting((event: KeyboardEvent): void => {
-            event.preventDefault();
+        },
+    },
+    'Shift+n': {
+        description: 'open newest entries page',
+        action: () => {
             document
                 .querySelector<HTMLAnchorElement>('#nav-filter-newest')
                 .click();
-        }),
-
-        // 'Shift+u': switch to unread items overview / menu item
-        'Shift+u': ignoreWhenInteracting((event: KeyboardEvent): void => {
-            event.preventDefault();
+        },
+    },
+    'Shift+u': {
+        description: 'open unread entries page',
+        action: () => {
             document
                 .querySelector<HTMLAnchorElement>('#nav-filter-unread')
                 .click();
-        }),
-
-        // 'Shift+s': switch to starred items overview / menu item
-        'Shift+s': ignoreWhenInteracting((event: KeyboardEvent): void => {
-            event.preventDefault();
+        },
+    },
+    'Shift+s': {
+        description: 'open starred entries page',
+        action: () => {
             document
                 .querySelector<HTMLAnchorElement>('#nav-filter-starred')
                 .click();
-        }),
-    });
+        },
+    },
+};
+
+function makeKeybindingsMap(): KeybindingsMap {
+    const shortcuts = Object.entries(KEYBINDINGS);
+    const keybindingsMap: KeybindingsMap = {};
+
+    for (const [keycombo, keybind] of shortcuts) {
+        keybindingsMap[keycombo] = ignoreWhenInteracting(
+            (event: KeyboardEvent) => {
+                event.preventDefault();
+                keybind.action(event);
+            },
+        );
+    }
+    return keybindingsMap;
+}
+
+/**
+ * Set up shortcuts on document.
+ */
+export default function makeShortcuts(): () => void {
+    return tinykeys(window, makeKeybindingsMap());
 }

--- a/client/js/templates/App.tsx
+++ b/client/js/templates/App.tsx
@@ -44,6 +44,7 @@ import locales, {
 } from '../locales';
 import { useEntriesParams, useLocation } from '../helpers/uri';
 import { NavSource, NavTag } from '../requests/items';
+import HelpPage from './HelpPage';
 
 type MessageAction = {
     label: string;
@@ -476,6 +477,12 @@ function PureApp(props: PureAppProps): React.JSX.Element {
                                             <SourcesPage
                                                 showError={showError}
                                             />
+                                        }
+                                    />
+                                    <Route
+                                        path="/help"
+                                        element={
+                                            <HelpPage />
                                         }
                                     />
                                     <Route path="*" element={<NotFound />} />

--- a/client/js/templates/HelpPage.tsx
+++ b/client/js/templates/HelpPage.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { KEYBINDINGS } from "../shortcuts";
 
-export default function HelpShortcuts(): React.JSX.Element {
+export default function HelpPage(): React.JSX.Element {
     const keycombos: string[] = Object.keys(KEYBINDINGS);
     return (
         <dl>

--- a/client/js/templates/HelpShortcuts.tsx
+++ b/client/js/templates/HelpShortcuts.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { KEYBINDINGS } from "../shortcuts";
+
+export default function HelpShortcuts(): React.JSX.Element {
+    const keycombos: string[] = Object.keys(KEYBINDINGS);
+    return (
+        <dl>
+            {keycombos.map((keycombo) => {
+                const keybinding = KEYBINDINGS[keycombo];
+
+                let readableKeycombo: React.JSX.Element;
+                if (keybinding.readableName) {
+                    readableKeycombo = (<kbd>{keybinding.readableName}</kbd>);
+                } else if (keycombo.includes("+")) {
+                    const keys = keycombo.split("+");
+                    readableKeycombo = (<>{keys.map((key: string, i: number) => (
+                        <><kbd>{key}</kbd>{i < keys.length-1 ? <span>+</span> : null}</>
+                    ))}</>);
+                } else {
+                    readableKeycombo = (<kbd>{keycombo}</kbd>);
+                }
+                return (
+                    <>
+                        <dt>{readableKeycombo}</dt>
+                        <dd>{keybinding.description}</dd>
+                    </>
+                )
+            })}
+        </dl>
+    )
+}
+
+

--- a/client/styles/_shared.scss
+++ b/client/styles/_shared.scss
@@ -1,0 +1,26 @@
+dl {
+    display: grid;
+    grid-template-columns: max-content auto;
+    grid-gap: 0.5rem;
+}
+
+dt {
+    font-weight: bolder;
+}
+
+@supports (display: grid) {
+    dd {
+        margin-left: 0;
+    }
+}
+
+kbd {
+    border: 1px solid #353535;
+    border-radius: 0.25rem;
+    padding: 0.1875rem 0.3125rem;
+    margin: 0.125rem;
+    color: #353535;
+    text-decoration: none;
+}
+
+

--- a/client/styles/main.scss
+++ b/client/styles/main.scss
@@ -1469,3 +1469,8 @@ img[src^='https://s.w.org/images/core/emoji'] {
 .collapse-css-transition {
     transition: height 280ms cubic-bezier(0.4, 0, 0.2, 1);
 }
+
+
+// Shared has to be on the bottom, or the border rule gets overwritten
+@import 'shared';
+

--- a/docs/sass/style.scss
+++ b/docs/sass/style.scss
@@ -1,3 +1,5 @@
+@import "../../client/styles/shared";
+
 $layout-width: 65rem;
 $content-width: 55rem;
 
@@ -42,22 +44,6 @@ code {
 img {
     border: 0;
     max-width: 100%;
-}
-
-dl {
-    display: grid;
-    grid-template-columns: max-content auto;
-    grid-gap: 0.5rem;
-}
-
-dt {
-    font-weight: bolder;
-}
-
-@supports (display: grid) {
-    dd {
-        margin-left: 0;
-    }
 }
 
 .wrapper-bright, .wrapper-dark {
@@ -317,15 +303,6 @@ li.nav-forge {
 .main td {
     font-size: 0.75rem;
     padding: 0.3125rem;
-}
-
-kbd {
-    border: 1px solid #353535;
-    border-radius: 0.25rem;
-    padding: 0.1875rem 0.3125rem;
-    margin: 0.125rem;
-    color: #353535;
-    text-decoration: none;
 }
 
 /************ footer **************/


### PR DESCRIPTION
Hi! Due to the 1st part of the code being done (streamline) and the second (help page) solely delayed by my troubles getting rid of Page Not Found in React, I thought I'd open the PR as a draft to possibly get feedback on the work so far.

Once finished, this will close #1143. Help in getting the page showing would be appreciated too!

### Shortcut streamlining (done)
- (Changed) KeybindingsMap is now generated from a simpler, less boilerplate-heavy format
            All keybindings have been tested manually since conversion
- (Description) Adapted shortcuts.ts descriptions to their equivalents from the docs
                https://github.com/fossar/selfoss/blob/81187a39a1b1db0e2d48fb0fccad949ca771a635/docs/content/docs/usage/shortcuts.md
    - Exception: "item" is replaced by "entry" for consistency
    - Exception: Renamed throws to throw to previous / throw to next
- (Keycombo readable name) Adapted arrow left & arrow right to the symbol used in docs
- (Refactor) Due to being closely related, moved ctrl+m to be next to m & j to be next so space

### Help page (wip)
- (Changed) move shortcut table styling to shared scss file, created HelpS…](https://github.com/fossar/selfoss/pull/1609/commits/bb2d08c3b76f8d3d17e78b345c64898948121f96) (done)
- (Addition) Create `?` shortcut (wip)
- (Addition) Create help page (wip)