### PR TITLE
client: Enable `eqeqeq` lint

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -26,6 +26,8 @@ const config = {
     files: ['**/*.ts', '**/*.tsx', '**/*.js'],
 
     rules: {
+        eqeqeq: 'error',
+
         'no-eval': 'error',
         'no-array-constructor': 'error',
         camelcase: 'error',

--- a/client/js/helpers/i18n.ts
+++ b/client/js/helpers/i18n.ts
@@ -107,7 +107,7 @@ export function i18nFormat(
         }
     }
 
-    if (state != 'out') {
+    if (state !== 'out') {
         return "Error formatting '" + translated + "', bug report?";
     }
 

--- a/client/js/helpers/uri.ts
+++ b/client/js/helpers/uri.ts
@@ -26,11 +26,11 @@ export function useLocation(): Location {
  * Converts URL segment to FilterType value.
  */
 export function filterTypeFromString(type: string): FilterType {
-    if (type == 'newest') {
+    if (type === 'newest') {
         return FilterType.NEWEST;
-    } else if (type == 'unread') {
+    } else if (type === 'unread') {
         return FilterType.UNREAD;
-    } else if (type == 'starred') {
+    } else if (type === 'starred') {
         return FilterType.STARRED;
     } else {
         throw new Error(`Invalid filter type: “${type}”`);
@@ -41,11 +41,11 @@ export function filterTypeFromString(type: string): FilterType {
  * Converts FilterType value to string usable in URL.
  */
 export function filterTypeToString(type: FilterType): string {
-    if (type == FilterType.NEWEST) {
+    if (type === FilterType.NEWEST) {
         return 'newest';
-    } else if (type == FilterType.UNREAD) {
+    } else if (type === FilterType.UNREAD) {
         return 'unread';
-    } else if (type == FilterType.STARRED) {
+    } else if (type === FilterType.STARRED) {
         return 'starred';
     } else {
         throw new Error(`Invalid filter type: “${type}”`);

--- a/client/js/selfoss-base.ts
+++ b/client/js/selfoss-base.ts
@@ -140,7 +140,7 @@ class selfoss {
 
         if (configuration.authEnabled) {
             this.loggedin.update(
-                window.localStorage.getItem('onlineSession') == 'true',
+                window.localStorage.getItem('onlineSession') === 'true',
             );
         }
 
@@ -450,7 +450,7 @@ class selfoss {
 
         const httpCode = 'response' in error ? error.response.status : 0;
 
-        if (tryOffline && httpCode != 403) {
+        if (tryOffline && httpCode !== 403) {
             return this.db.setOffline();
         } else {
             return Promise.reject(error);

--- a/client/js/selfoss-db-offline.ts
+++ b/client/js/selfoss-db-offline.ts
@@ -325,13 +325,13 @@ export default class DbOffline {
                             if (ascOrder) {
                                 keepEntry &&=
                                     entry.datetime > fromDatetime ||
-                                    (entry.datetime.getTime() ==
+                                    (entry.datetime.getTime() ===
                                         fromDatetime.getTime() &&
                                         entry.id > fromId);
                             } else {
                                 keepEntry &&=
                                     entry.datetime < fromDatetime ||
-                                    (entry.datetime.getTime() ==
+                                    (entry.datetime.getTime() ===
                                         fromDatetime.getTime() &&
                                         entry.id < fromId);
                             }

--- a/client/js/templates/EntriesPage.tsx
+++ b/client/js/templates/EntriesPage.tsx
@@ -514,7 +514,7 @@ export function EntriesPage(props: EntriesPageProps): React.JSX.Element {
                     key={entry.id}
                     item={entry}
                     currentTime={currentTime}
-                    selected={selectedEntry == entry.id}
+                    selected={selectedEntry === entry.id}
                     expanded={expandedEntries[entry.id] ?? false}
                     setNavExpanded={setNavExpanded}
                     showError={showError}
@@ -557,7 +557,7 @@ export function EntriesPage(props: EntriesPageProps): React.JSX.Element {
                         <span>{_('markread')}</span>
                     </button>
                 ) : null}
-                {loadingState == LoadingState.FAILURE ? (
+                {loadingState === LoadingState.FAILURE ? (
                     <button
                         className="stream-button stream-error"
                         aria-live="assertive"
@@ -792,7 +792,7 @@ export class StateHolder extends React.Component<
         this.state.entries.forEach((entry) => {
             const { id } = entry;
             const newStatus = entryStatuses.find(
-                (entryStatus) => entryStatus.id == id,
+                (entryStatus) => entryStatus.id === id,
             );
             if (newStatus) {
                 this.starEntryInView(id, newStatus.starred);
@@ -1147,12 +1147,12 @@ export class StateHolder extends React.Component<
      * get next/prev item
      */
     nextPrev(direction: Direction, open: boolean = true): void {
-        if (direction != Direction.NEXT && direction != Direction.PREV) {
+        if (direction !== Direction.NEXT && direction !== Direction.PREV) {
             throw new Error('direction must be one of Direction.{PREV,NEXT}');
         }
 
         // when there are no entries
-        if (this.state.entries.length == 0) {
+        if (this.state.entries.length === 0) {
             return;
         }
 
@@ -1166,7 +1166,7 @@ export class StateHolder extends React.Component<
 
         // select next/prev entry and save it to "current"
         // if we would overflow, we stay on the old one
-        if (direction == Direction.NEXT) {
+        if (direction === Direction.NEXT) {
             if (old === null) {
                 current = this.state.entries[0].id;
             } else {
@@ -1222,7 +1222,7 @@ export class StateHolder extends React.Component<
      * entry navigation (next/prev) with keys
      */
     entryNav(direction: Direction): void {
-        if (direction != Direction.NEXT && direction != Direction.PREV) {
+        if (direction !== Direction.NEXT && direction !== Direction.PREV) {
             throw new Error('direction must be one of Direction.{PREV,NEXT}');
         }
 

--- a/client/js/templates/Item.tsx
+++ b/client/js/templates/Item.tsx
@@ -567,9 +567,7 @@ export default function Item(props: ItemProps): React.JSX.Element {
                 aria-hidden="true"
                 onClick={preventDefaultOnSmartphone}
             >
-                {item.icon !== null &&
-                item.icon.trim().length > 0 &&
-                item.icon != '0' ? (
+                {item.icon !== null ? (
                     <img
                         src={`favicons/${item.icon}`}
                         aria-hidden="true"

--- a/client/js/templates/Item.tsx
+++ b/client/js/templates/Item.tsx
@@ -35,7 +35,7 @@ import { ResponseItem, TagColor } from '../requests/items';
 // TODO: do the search highlights client-side
 function reHighlight(text: string): (React.JSX.Element | string)[] {
     return text.split(/<span class="found">(.+?)<\/span>/).map((n, i) =>
-        i % 2 == 0 ? (
+        i % 2 === 0 ? (
             n
         ) : (
             <span key={i} className="found">

--- a/client/js/templates/NavSearch.tsx
+++ b/client/js/templates/NavSearch.tsx
@@ -60,10 +60,10 @@ function handleFieldKeyUp({
     searchRemoveButton: RefObject<HTMLButtonElement>;
 }): void {
     // keypress enter in search inputfield
-    if (event.which == 13) {
+    if (event.which === 13) {
         searchButton.current.click();
     }
-    if (event.keyCode == 27) {
+    if (event.keyCode === 27) {
         searchRemoveButton.current.click();
     }
 }
@@ -85,7 +85,7 @@ function handleRemove({
 
     setActive(false);
 
-    if (oldTerm == '') {
+    if (oldTerm === '') {
         searchField.current.blur();
         return;
     }

--- a/client/js/templates/SearchList.tsx
+++ b/client/js/templates/SearchList.tsx
@@ -7,7 +7,7 @@ import { makeEntriesLink } from '../helpers/uri';
 import * as icons from '../icons';
 
 function splitTerm(term: string): string[] {
-    if (term == '') {
+    if (term === '') {
         return [];
     } else if (term.match(/^\/.+\/$/)) {
         return [term];

--- a/client/js/templates/Source.tsx
+++ b/client/js/templates/Source.tsx
@@ -800,7 +800,7 @@ export default function Source(props: SourceProps): React.JSX.Element {
             ref={sourceElem}
         >
             <div className="source-icon">
-                {source.icon && source.icon != '0' ? (
+                {source.icon !== null ? (
                     <img
                         src={`favicons/${source.icon}`}
                         aria-hidden="true"

--- a/client/js/templates/Source.tsx
+++ b/client/js/templates/Source.tsx
@@ -190,7 +190,7 @@ function handleDelete(args: {
         _,
     } = args;
     const answer = confirm(_('source_warn'));
-    if (answer == false) {
+    if (!answer) {
         return;
     }
 

--- a/client/js/templates/SourceParam.tsx
+++ b/client/js/templates/SourceParam.tsx
@@ -73,6 +73,7 @@ export default function SourceParam(
         let checked;
 
         if (spoutParam.type === 'checkbox') {
+            // eslint-disable-next-line eqeqeq -- Unclear if the type is correct since this is not used by any spout.
             checked = value == '1';
             // Value always has to be 1 since HTML sends [name]=[value] when a checkbox is checked
             // and omits the field altogether from HTTP request when not checked.

--- a/src/daos/mysql/Items.php
+++ b/src/daos/mysql/Items.php
@@ -325,7 +325,7 @@ class Items implements \Selfoss\daos\ItemsInterface {
 
         // get items from database
         $select = 'SELECT
-            items.id, datetime, items.title AS title, content, unread, starred, source, thumbnail, icon, uid, link, updatetime, author, sources.title as sourcetitle, sources.tags as tags
+            items.id, datetime, items.title AS title, content, unread, starred, source, thumbnail, NULLIF(icon, \'\') as icon, uid, link, updatetime, author, sources.title as sourcetitle, sources.tags as tags
             FROM ' . $this->configuration->dbPrefix . 'items AS items, ' . $this->configuration->dbPrefix . 'sources AS sources
             WHERE items.source=sources.id AND';
         $order_sql = 'ORDER BY items.datetime ' . $order . ', items.id ' . $order;


### PR DESCRIPTION
Using weak comparison is overly confusing:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Equality_comparisons_and_sameness
https://dorey.github.io/JavaScript-Equality-Table/

Let’s switch to strict one where the value domain is clear and enforce this with an eslint rule:
https://eslint.org/docs/latest/rules/eqeqeq

In places where the correctness was not obvious, adding a suppression comment until it is cleared.

Marked as WIP since the normalization in items dao should be part of migration.
