### PR TITLE
configuration: Allow loading `password` and `db_password` from file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 - Garbage collection can be completely disabled by setting `items_lifetime=0`.
 - Tamil (`ta`) translation was added.
 - Configuration file path can be overridden with `SELFOSS_CONFIG_PATH` environment variable. Alternately, you can specify `SELFOSS_CONFIG_DIR` where selfoss will look for `config.ini`. ([#1603](https://github.com/fossar/selfoss/pull/1603))
+- Password hash and database password can be now loaded from a file specified by `password_file` and `db_password_file` option, respectively. ([#1624](https://github.com/fossar/selfoss/pull/1624))
 
 ### Bug fixes
 - Configuration parser was changed to *raw* method, which relaxes the requirement to quote option values containing special characters in `config.ini`. ([#1371](https://github.com/fossar/selfoss/issues/1371))

--- a/docs/content/docs/administration/options.md
+++ b/docs/content/docs/administration/options.md
@@ -26,19 +26,19 @@ address/hostname of the database server for MySQL/PostgreSQL
 ### `db_database`
 <div class="config-option">
 
-name of the database
+Name of the MySQL or PostgreSQL database
 </div>
 
 ### `db_username`
 <div class="config-option">
 
-database username
+Database username for MySQL or PostgreSQL
 </div>
 
 ### `db_password`
 <div class="config-option">
 
-database password
+Database password for MySQL and PostgreSQL.
 </div>
 
 ### `db_prefix`

--- a/docs/content/docs/administration/options.md
+++ b/docs/content/docs/administration/options.md
@@ -41,6 +41,18 @@ Database username for MySQL or PostgreSQL
 Database password for MySQL or PostgreSQL.
 
 For PostgreSQL on local server, [peer authentication](https://www.postgresql.org/docs/18/auth-peer.html) might be more secure an convenient, as it does not require a password. This is also available as [`unix_socket` authentication plugin](https://mariadb.com/docs/server/reference/plugins/authentication-plugins/authentication-plugin-unix-socket) on MariaDB.
+
+Prefer [`db_password_file`](#db-password-file) if the configuration is readable by other users.
+</div>
+
+### `db_password_file`
+<div class="config-option">
+
+A path to a file containing database password.
+
+This allows storing the password outside of the configuration, which may be more secure if the configuration is readable by other users. It is also allows provisioning the password separately using some secrets management system.
+
+To avoid leaking the password to other services, the file should [only be accessible](https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html#23-access-control) by the user running the PHP server used by selfoss.
 </div>
 
 ### `db_prefix`
@@ -113,6 +125,12 @@ username for optional login. Just set username and password for enabling login.
 <div class="config-option">
 
 password hash for optional login. You can generate a password hash by using following page of your selfoss installation. https://your_selfoss_url.com/password
+</div>
+
+### `password_file`
+<div class="config-option">
+
+Alternative to [`password`](#password) option, a path to a file containing the password hash. This is useful for provisioning the password using a secrets management system.
 </div>
 
 ### <del>`salt`</del> (deprecated)

--- a/docs/content/docs/administration/options.md
+++ b/docs/content/docs/administration/options.md
@@ -38,7 +38,9 @@ Database username for MySQL or PostgreSQL
 ### `db_password`
 <div class="config-option">
 
-Database password for MySQL and PostgreSQL.
+Database password for MySQL or PostgreSQL.
+
+For PostgreSQL on local server, [peer authentication](https://www.postgresql.org/docs/18/auth-peer.html) might be more secure an convenient, as it does not require a password. This is also available as [`unix_socket` authentication plugin](https://mariadb.com/docs/server/reference/plugins/authentication-plugins/authentication-plugin-unix-socket) on MariaDB.
 </div>
 
 ### `db_prefix`

--- a/src/helpers/Configuration.php
+++ b/src/helpers/Configuration.php
@@ -52,6 +52,8 @@ final class Configuration {
 
     public string $dbUsername = 'root';
 
+    private string $dbPasswordFile = '';
+
     public string $dbPassword = '';
 
     public ?int $dbPort = null;
@@ -71,6 +73,8 @@ final class Configuration {
     public string $baseUrl = '';
 
     public string $username = '';
+
+    private string $passwordFile = '';
 
     public string $password = '';
 
@@ -199,8 +203,7 @@ final class Configuration {
                 throw new Exception("Unknown type “{$propertyType}” for property “{$propertyName}”.", 1);
             }
 
-            $this->{$propertyName} = $value;
-            $this->modifiedOptions[$propertyName] = true;
+            $this->setValue($propertyName, $value);
         }
 
         // Interpolate variables in the config values.
@@ -208,6 +211,26 @@ final class Configuration {
         foreach (self::INTERPOLATED_PROPERTIES as $property) {
             $value = $this->{$property};
             $this->{$property} = str_replace('%datadir%', $datadir, $value);
+        }
+
+        $this->loadFromPath('password', 'password');
+        $this->loadFromPath('dbPassword', 'db_password');
+    }
+
+    private function setValue(string $propertyName, mixed $value): void {
+        $this->{$propertyName} = $value;
+        $this->modifiedOptions[$propertyName] = true;
+    }
+
+    private function loadFromPath(string $propertyName, string $option): void {
+        if ($this->isChanged($propertyName . 'File')) {
+            if ($this->isChanged($propertyName)) {
+                throw new Exception("You cannot set both `$option` and `{$option}_file` options.");
+            }
+            $value = @file_get_contents($this->{$propertyName . 'File'});
+            if ($value !== false) {
+                $this->setValue($propertyName, rtrim($value, "\r\n"));
+            }
         }
     }
 


### PR DESCRIPTION
Introduce `_file` suffixed variants of those options to make provisioning via secrets management system easier and to avoid leaking the db password when the configuration is world readable.

Also adjust the docs of `db_*` options.
