### PR TITLE
error.500.phtml: Fix using renamed Tracy method

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -31,6 +31,8 @@ $rules = [
     'phpdoc_align' => false,
     'phpdoc_no_empty_return' => false,
     'phpdoc_summary' => false,
+    // Useful for PHPStan in phtml templates.
+    'phpdoc_to_comment' => ['ignored_tags' => ['var']],
     'trailing_comma_in_multiline' => false,
     'yoda_style' => false,
     'semicolon_after_instruction' => false,

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -8,6 +8,11 @@ parameters:
         - index.php
         - run.php
 
+
+    fileExtensions:
+        - php
+        - phtml
+
     bootstrapFiles:
         - src/constants.php
         - vendor/bin/.phpunit/phpunit/vendor/autoload.php

--- a/src/error.500.phtml
+++ b/src/error.500.phtml
@@ -8,15 +8,11 @@ declare(strict_types=1);
 
 use Tracy\Helpers;
 
-/*
- * Default error page.
- *
- * @param bool $logged
- */
-
+/** @var bool $logged */
 ?>
 <!DOCTYPE html><!-- "' --></textarea></script></style></pre></xmp></a></audio></button></canvas></datalist></details></dialog></iframe></listing></meter></noembed></noframes></noscript></optgroup></option></progress></rp></select></table></template></title></video>
 <meta charset="utf-8">
+<meta name=viewport content="width=device-width, initial-scale=1">
 <meta name=robots content=noindex>
 <meta name=generator content="Tracy">
 <title>selfoss failed</title>

--- a/src/error.500.phtml
+++ b/src/error.500.phtml
@@ -52,6 +52,6 @@ use Tracy\Helpers;
     </div>
 </div>
 
-<script<?= Helpers::getNonceAttr() ?>>
+<script<?= Helpers::getNonce(attr: true) ?>>
     document.body.insertBefore(document.getElementById('tracy-error'), document.body.firstChild);
 </script>


### PR DESCRIPTION
Turns out Tracy 2.11.3 renamed `Tracy\Helpers::getNonceAttr()` back to `getNonce`:
https://github.com/nette/tracy/commit/a7ed8588e35ca9ee4629b96753cd9c8b49c5749e

Fortunately, the option to get attribute was added back in 2.11.4:
https://github.com/nette/tracy/commit/cada412942981015722f59da6fc3f30b91d94d3c

This was not caught during the update (00ea6937b5731793b41a1446ad80d3d52d3af22a) because we were not running PHPStan on the file. Let’s validate phtml files as well.
